### PR TITLE
Convert STL to USD

### DIFF
--- a/tests/data/assets/box.stl
+++ b/tests/data/assets/box.stl
@@ -1,86 +1,86 @@
-solid stdin
-  facet normal 0.000000000e+00 0.000000000e+00 1.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 0.000000000e+00 -1.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 1.000000000e+00 0.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 -1.000000000e+00 0.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal 1.000000000e+00 0.000000000e+00 0.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal -1.000000000e+00 0.000000000e+00 0.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-  facet normal -1.000000000e+00 0.000000000e+00 0.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal 1.000000000e+00 0.000000000e+00 0.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 -1.000000000e+00 0.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 1.000000000e+00 0.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 0.000000000e+00 -1.000000000e+00
-    outer loop
-      vertex -5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 -5.000000000e-01 -5.000000000e-01
-      vertex 5.000000000e-01 5.000000000e-01 -5.000000000e-01
-    endloop
-  endfacet
-  facet normal 0.000000000e+00 0.000000000e+00 1.000000000e+00
-    outer loop
-      vertex 5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 -5.000000000e-01 5.000000000e-01
-      vertex -5.000000000e-01 5.000000000e-01 5.000000000e-01
-    endloop
-  endfacet
-endsolid
+solid 
+facet normal -1 -0 -0
+ outer loop
+  vertex -0.5 -0.5 -0.5
+  vertex -0.5 -0.5 0.5
+  vertex -0.5 0.5 0.5
+ endloop
+endfacet
+facet normal -1 -0 0
+ outer loop
+  vertex -0.5 -0.5 -0.5
+  vertex -0.5 0.5 0.5
+  vertex -0.5 0.5 -0.5
+ endloop
+endfacet
+facet normal 0 1 0
+ outer loop
+  vertex -0.5 0.5 -0.5
+  vertex -0.5 0.5 0.5
+  vertex 0.5 0.5 0.5
+ endloop
+endfacet
+facet normal 0 1 -0
+ outer loop
+  vertex -0.5 0.5 -0.5
+  vertex 0.5 0.5 0.5
+  vertex 0.5 0.5 -0.5
+ endloop
+endfacet
+facet normal 1 -0 0
+ outer loop
+  vertex 0.5 0.5 -0.5
+  vertex 0.5 0.5 0.5
+  vertex 0.5 -0.5 0.5
+ endloop
+endfacet
+facet normal 1 -0 0
+ outer loop
+  vertex 0.5 0.5 -0.5
+  vertex 0.5 -0.5 0.5
+  vertex 0.5 -0.5 -0.5
+ endloop
+endfacet
+facet normal 0 -1 0
+ outer loop
+  vertex 0.5 -0.5 -0.5
+  vertex 0.5 -0.5 0.5
+  vertex -0.5 -0.5 0.5
+ endloop
+endfacet
+facet normal 0 -1 0
+ outer loop
+  vertex 0.5 -0.5 -0.5
+  vertex -0.5 -0.5 0.5
+  vertex -0.5 -0.5 -0.5
+ endloop
+endfacet
+facet normal 0 0 -1
+ outer loop
+  vertex -0.5 0.5 -0.5
+  vertex 0.5 0.5 -0.5
+  vertex 0.5 -0.5 -0.5
+ endloop
+endfacet
+facet normal 0 0 -1
+ outer loop
+  vertex -0.5 0.5 -0.5
+  vertex 0.5 -0.5 -0.5
+  vertex -0.5 -0.5 -0.5
+ endloop
+endfacet
+facet normal 0 0 1
+ outer loop
+  vertex 0.5 0.5 0.5
+  vertex -0.5 0.5 0.5
+  vertex -0.5 -0.5 0.5
+ endloop
+endfacet
+facet normal 0 -0 1
+ outer loop
+  vertex 0.5 0.5 0.5
+  vertex -0.5 -0.5 0.5
+  vertex 0.5 -0.5 0.5
+ endloop
+endfacet
+endsolid 

--- a/tests/testMesh.py
+++ b/tests/testMesh.py
@@ -3,14 +3,16 @@
 import pathlib
 
 import usdex.test
-from pxr import Tf
+from pxr import Tf, Usd, UsdGeom
 
 import urdf_usd_converter
 from tests.util.ConverterTestCase import ConverterTestCase
 
 
 class TestMesh(ConverterTestCase):
-    def test_mesh_conversion(self):
+    def setUp(self):
+        super().setUp()
+
         input_path = "tests/data/meshes.urdf"
         output_dir = self.tmpDir()
 
@@ -18,7 +20,6 @@ class TestMesh(ConverterTestCase):
         with usdex.test.ScopedDiagnosticChecker(
             self,
             [
-                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*The stl format is not yet supported:.*"),
                 (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*The obj format is not yet supported:.*"),
                 (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*The dae format is not yet supported:.*"),
                 (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Unsupported mesh format:.*"),
@@ -26,5 +27,36 @@ class TestMesh(ConverterTestCase):
             level=usdex.core.DiagnosticsLevel.eWarning,
         ):
             asset_path = converter.convert(input_path, output_dir)
+
         self.assertIsNotNone(asset_path)
         self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        self.stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(self.stage)
+
+    def test_stl_mesh(self):
+        default_prim = self.stage.GetDefaultPrim()
+        geometry_scope_prim = self.stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        # Test STL mesh conversion
+        link_stl_prim = self.stage.GetPrimAtPath(geometry_scope_prim.GetPath().AppendChild("link_mesh_stl"))
+        self.assertTrue(link_stl_prim.IsValid())
+        self.assertTrue(link_stl_prim.IsA(UsdGeom.Xform))
+
+        stl_mesh_prim = self.stage.GetPrimAtPath(link_stl_prim.GetPath().AppendChild("box"))
+        self.assertTrue(stl_mesh_prim.IsValid())
+        self.assertTrue(stl_mesh_prim.IsA(UsdGeom.Mesh))
+        self.assertTrue(stl_mesh_prim.HasAuthoredReferences())
+
+        usd_mesh_stl = UsdGeom.Mesh(stl_mesh_prim)
+        self.assertTrue(usd_mesh_stl.GetPointsAttr().HasAuthoredValue())
+        self.assertTrue(usd_mesh_stl.GetFaceVertexCountsAttr().HasAuthoredValue())
+        self.assertTrue(usd_mesh_stl.GetFaceVertexIndicesAttr().HasAuthoredValue())
+        # The sample box.stl has normals and they are authored as a primvar
+        self.assertFalse(usd_mesh_stl.GetNormalsAttr().HasAuthoredValue())
+        normals_primvar: UsdGeom.Primvar = UsdGeom.PrimvarsAPI(usd_mesh_stl).GetPrimvar("normals")
+        self.assertTrue(normals_primvar.IsDefined())
+        self.assertTrue(normals_primvar.HasAuthoredValue())
+        self.assertTrue(normals_primvar.GetIndicesAttr().HasAuthoredValue())
+        self.assertEqual(UsdGeom.Imageable(stl_mesh_prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)


### PR DESCRIPTION
## Description

Fixes #7 

Convert STL to USD.  

- The same code as [mujoco-usd-converter](https://github.com/newton-physics/mujoco-usd-converter/blob/main/mujoco_usd_converter/_impl/mesh.py#L69) was used to load the STL.
- The faces of [box.stl](https://github.com/newton-physics/urdf-usd-converter/blob/main/tests/data/assets/box.stl) were inverted, so I recreated it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
