### PR TITLE
Add diagnostic warnings

### DIFF
--- a/tests/data/verifying_elements.urdf
+++ b/tests/data/verifying_elements.urdf
@@ -98,4 +98,8 @@
       <hardwareInterface>EffortJointInterface</hardwareInterface>
     </actuator>
   </transmission>
+
+  <gazebo>
+    <static>true</static>
+  </gazebo>
 </robot>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -521,30 +521,43 @@ class TestURDFParser(ConverterTestCase):
 
         # Get undefined elements.
         undefined_elements = self.parser.get_undefined_elements()
-        self.assertEqual(len(undefined_elements), 5)
+        self.assertEqual(len(undefined_elements), 7)
 
         element = undefined_elements[0]
+        self.assertEqual(element.tag, "gazebo")
+        self.assertEqual(element.path, "/robot/gazebo")
+        self.assertEqual(element.undefined_element, True)
+        self.assertEqual(element.line_number, 102)
+
+        element = undefined_elements[1]
+        self.assertEqual(element.tag, "static")
+        self.assertEqual(element.path, "/robot/gazebo/static")
+        self.assertEqual(element.undefined_element, True)
+        self.assertEqual(element.undefined_text, "true")
+        self.assertEqual(element.line_number, 103)
+
+        element = undefined_elements[2]
         self.assertEqual(element.tag, "custom")
         self.assertEqual(element.path, "/robot/link/visual/custom")
         self.assertEqual(element.undefined_element, True)
         self.assertEqual(element.undefined_attributes, {})
         self.assertEqual(element.line_number, 29)
 
-        element = undefined_elements[1]
+        element = undefined_elements[3]
         self.assertEqual(element.tag, "item1")
         self.assertEqual(element.path, "/robot/link/visual/custom/item1")
         self.assertEqual(element.undefined_element, True)
         self.assertEqual(element.undefined_attributes, {"name": "data1", "value": "1"})
         self.assertEqual(element.line_number, 30)
 
-        element = undefined_elements[2]
+        element = undefined_elements[4]
         self.assertEqual(element.tag, "item2")
         self.assertEqual(element.path, "/robot/link/visual/custom/item2")
         self.assertEqual(element.undefined_element, True)
         self.assertEqual(element.undefined_attributes, {"name": "data2", "value": "2"})
         self.assertEqual(element.line_number, 31)
 
-        element = undefined_elements[3]
+        element = undefined_elements[5]
         self.assertEqual(element.tag, "data")
         self.assertEqual(element.path, "/robot/link/visual/custom/data")
         self.assertEqual(element.undefined_element, True)
@@ -554,7 +567,7 @@ class TestURDFParser(ConverterTestCase):
 
         # When adding custom attributes to an existing element.
         # In this case, element.undefined_element will be False.
-        element = undefined_elements[4]
+        element = undefined_elements[6]
         self.assertEqual(element.tag, "visual")
         self.assertEqual(element.path, "/robot/link/visual")
         self.assertEqual(element.undefined_element, False)

--- a/urdf_usd_converter/_impl/convert.py
+++ b/urdf_usd_converter/_impl/convert.py
@@ -13,6 +13,7 @@ from .link import convert_links
 from .material import convert_materials
 from .mesh import convert_meshes
 from .scene import convert_scene
+from .urdf_parser.elements import ElementRobot
 from .urdf_parser.parser import URDFParser
 from .utils import get_authoring_metadata
 
@@ -128,4 +129,36 @@ class Converter:
         else:
             usdex.core.saveStage(asset_stage, comment=self.params.comment)
 
+        # warn about known limitations
+        self.warn(parser)
+
         return Sdf.AssetPath(asset_identifier)
+
+    def warn(self, parser: URDFParser):
+        element_root: ElementRobot = parser.get_root_element()
+
+        if element_root.transmissions:
+            Tf.Warn("Transmissions are not supported")
+
+        if "gazebo" in [element.tag for element in element_root.undefined_elements]:
+            Tf.Warn("Gazebo is not supported")
+
+        for joint in element_root.joints:
+            if joint.calibration:
+                Tf.Warn("Calibration is not supported")
+                break
+
+        for joint in element_root.joints:
+            if joint.dynamics:
+                Tf.Warn("Dynamics is not supported")
+                break
+
+        for joint in element_root.joints:
+            if joint.mimic:
+                Tf.Warn("Mimic is not supported")
+                break
+
+        for joint in element_root.joints:
+            if joint.safety_controller:
+                Tf.Warn("Safety controller is not supported")
+                break


### PR DESCRIPTION
## Description

Fixes #17

Add diagnostic warnings for all known limitations.  
Warnings about terminal parameters during conversion will be implemented in separate branches, such as PR #25.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).

## Other current Tf.Warn

*  joint - floating joints (PR #25)
* link - visual/collision - geometry - mesh: For files other than stl/obj/dae (PR #25)
