### PR TITLE
Fix the spdx license to say The Newton Developers

### DIFF
--- a/tests/testCli.py
+++ b/tests/testCli.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 import shutil

--- a/tests/testConverter.py
+++ b/tests/testConverter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 

--- a/tests/util/ConverterTestCase.py
+++ b/tests/util/ConverterTestCase.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 import omni.asset_validator

--- a/tools/license_format.py
+++ b/tools/license_format.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import logging
@@ -7,7 +7,7 @@ import re
 import sys
 from datetime import datetime
 
-__copyright = "# SPDX-FileCopyrightText: Copyright (c) {years} NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+__copyright = "# SPDX-FileCopyrightText: Copyright (c) {years} The Newton Developers"
 __identifier = "# SPDX-License-Identifier: Apache-2.0"
 # Escape special regex characters in the copyright template
 __copyright_template = re.escape(__copyright).replace(re.escape("{years}"), "{years}")

--- a/tools/update_markdown_for_pypi.py
+++ b/tools/update_markdown_for_pypi.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 """
 Update Markdown links for PyPI

--- a/tools/upload_wheel.py
+++ b/tools/upload_wheel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 """
 Python wheel upload script for JFrog Artifactory.

--- a/urdf_usd_converter/__init__.py
+++ b/urdf_usd_converter/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 from ._impl.convert import Converter
 from ._version import __version__

--- a/urdf_usd_converter/__main__.py
+++ b/urdf_usd_converter/__main__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import sys
 

--- a/urdf_usd_converter/_impl/_flatten.py
+++ b/urdf_usd_converter/_impl/_flatten.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 import shutil

--- a/urdf_usd_converter/_impl/cli.py
+++ b/urdf_usd_converter/_impl/cli.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 from pathlib import Path

--- a/urdf_usd_converter/_impl/convert.py
+++ b/urdf_usd_converter/_impl/convert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 import tempfile

--- a/urdf_usd_converter/_impl/data.py
+++ b/urdf_usd_converter/_impl/data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 from .data import ConversionData
 

--- a/urdf_usd_converter/_impl/material.py
+++ b/urdf_usd_converter/_impl/material.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import usdex.core
 

--- a/urdf_usd_converter/_impl/mesh.py
+++ b/urdf_usd_converter/_impl/mesh.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import usdex.core
 

--- a/urdf_usd_converter/_impl/scene.py
+++ b/urdf_usd_converter/_impl/scene.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 from .data import ConversionData
 

--- a/urdf_usd_converter/_impl/urdf_parser/elements.py
+++ b/urdf_usd_converter/_impl/urdf_parser/elements.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 # Elements defined in the URDF Schema.

--- a/urdf_usd_converter/_impl/urdf_parser/line_number_parser.py
+++ b/urdf_usd_converter/_impl/urdf_parser/line_number_parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 import xml.etree.ElementTree as ET

--- a/urdf_usd_converter/_impl/urdf_parser/parser.py
+++ b/urdf_usd_converter/_impl/urdf_parser/parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 import xml.etree.ElementTree as ET

--- a/urdf_usd_converter/_impl/urdf_parser/reserved_element_attribute_names.py
+++ b/urdf_usd_converter/_impl/urdf_parser/reserved_element_attribute_names.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 # Reserved attribute names for elements.

--- a/urdf_usd_converter/_impl/urdf_parser/undefined_data.py
+++ b/urdf_usd_converter/_impl/urdf_parser/undefined_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 from .elements import ElementBase

--- a/urdf_usd_converter/_impl/utils.py
+++ b/urdf_usd_converter/_impl/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 from .._version import __version__
 

--- a/urdf_usd_converter/_version.py
+++ b/urdf_usd_converter/_version.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 __version__ = "0.1.0dev0"


### PR DESCRIPTION
## Description

Fixes #28 

Fix the spdx license to say The Newton Developers  

* Updated ```tools/license_format.py```
* Updated spdx license in all code headers (```poe format``` applied)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
