### PR TITLE
Enable loading of invalid URDF files

### DIFF
--- a/tests/data/warning_different_place.urdf
+++ b/tests/data/warning_different_place.urdf
@@ -1,7 +1,9 @@
-<robot name="different_places">
+<robot name="warning_different_place">
   <link name="BaseLink">
     <visual>
-      <material name="green" />
+      <material name="green">
+        <color rgba="0.0 1.0 0.0 1"/>
+      </material>
     </visual>
     <!-- This is a deliberate mistake.  -->
     <!-- The geometry is not a child of the visual. -->

--- a/tests/data/warning_incorrect_visual_geometry_name.urdf
+++ b/tests/data/warning_incorrect_visual_geometry_name.urdf
@@ -1,4 +1,4 @@
-<robot name="incorrect_visual_geometry_name">
+<robot name="warning_incorrect_visual_geometry_name">
   <link name="BaseLink">
     <visual>
       <!-- This is a deliberate mistake.  -->

--- a/tests/data/warning_invalid_material_name.urdf
+++ b/tests/data/warning_invalid_material_name.urdf
@@ -1,4 +1,4 @@
-<robot name="invalid_material_name">
+<robot name="warning_invalid_material_name">
   <material name="red">
     <color rgba="1.0 0.0 0.0 1"/>
   </material>

--- a/tests/data/warning_missing_collision_geometry.urdf
+++ b/tests/data/warning_missing_collision_geometry.urdf
@@ -1,10 +1,15 @@
-<robot name="missing_visual_geometry">
+<robot name="warning_missing_collision_geometry">
   <link name="BaseLink">
     <visual>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+    <collision>
       <!-- This is a deliberate mistake.  -->
       <!-- The specified geometry does not exist. -->
       <geometry>
       </geometry>
-    </visual>
+    </collision>
   </link>
 </robot>

--- a/tests/data/warning_missing_visual_geometry.urdf
+++ b/tests/data/warning_missing_visual_geometry.urdf
@@ -1,15 +1,10 @@
-<robot name="missing_collision_geometry">
+<robot name="warning_missing_visual_geometry">
   <link name="BaseLink">
     <visual>
-      <geometry>
-        <box size="1 1 1"/>
-      </geometry>
-    </visual>
-    <collision>
       <!-- This is a deliberate mistake.  -->
       <!-- The specified geometry does not exist. -->
       <geometry>
       </geometry>
-    </collision>
+    </visual>
   </link>
 </robot>

--- a/tests/data/warning_no_joint_k_velocity.urdf
+++ b/tests/data/warning_no_joint_k_velocity.urdf
@@ -1,4 +1,4 @@
-<robot name="no_joint_k_velocity">
+<robot name="warning_no_joint_k_velocity">
   <link name="BaseLink">
     <visual>
       <origin rpy="0 0 0" xyz="-2 0 0.5"/>

--- a/tests/data/warning_no_mesh_filename.urdf
+++ b/tests/data/warning_no_mesh_filename.urdf
@@ -1,4 +1,4 @@
-<robot name="no_mesh_filename">
+<robot name="warning_no_mesh_filename">
   <link name="BaseLink">
     <visual>
       <origin rpy="0 0 0" xyz="-2 0 0.5"/>

--- a/tests/data/warning_obj_no_exist_filename.urdf
+++ b/tests/data/warning_obj_no_exist_filename.urdf
@@ -1,4 +1,4 @@
-<robot name="obj_no_exist_filename">
+<robot name="warning_obj_no_exist_filename">
   <link name="BaseLink">
     <visual>
       <geometry>

--- a/tests/data/warning_obj_no_shape.urdf
+++ b/tests/data/warning_obj_no_shape.urdf
@@ -1,4 +1,4 @@
-<robot name="obj_no_shape">
+<robot name="warning_obj_no_shape">
   <link name="BaseLink">
     <visual>
       <geometry>

--- a/tests/testConverter.py
+++ b/tests/testConverter.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 
+import usdex.test
+from pxr import Tf
+
 import urdf_usd_converter
 from tests.util.ConverterTestCase import ConverterTestCase
 
@@ -44,22 +47,34 @@ class TestConverter(ConverterTestCase):
         with self.assertRaisesRegex(ValueError, r".*Closed loop articulations are not supported.*"):
             converter.convert(input_path, output_dir)
 
-    def test_load_error_obj_no_exist_filename(self):
+    def test_load_warning_obj_no_exist_filename(self):
         # A non-existent obj file is specified.
 
-        input_path = "tests/data/error_obj_no_exist_filename.urdf"
-        output_dir = str(pathlib.Path(self.tmpDir()) / "error_obj_no_exist_filename")
+        input_path = "tests/data/warning_obj_no_exist_filename.urdf"
+        output_dir = str(pathlib.Path(self.tmpDir()) / "warning_obj_no_exist_filename")
 
         converter = urdf_usd_converter.Converter()
-        with self.assertRaisesRegex(RuntimeError, r".*could not be parsed..*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*could not be parsed. Cannot open file.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             converter.convert(input_path, output_dir)
 
-    def test_load_error_obj_no_shape(self):
+    def test_load_warning_obj_no_shape(self):
         # There is no shape.
 
-        input_path = "tests/data/error_obj_no_shape.urdf"
+        input_path = "tests/data/warning_obj_no_shape.urdf"
         output_dir = str(pathlib.Path(self.tmpDir()) / "error_obj_no_shape")
 
         converter = urdf_usd_converter.Converter()
-        with self.assertRaisesRegex(RuntimeError, r".*contains no meshes.*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*contains no meshes.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             converter.convert(input_path, output_dir)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 
+import usdex.core
+from pxr import Tf
+
 from tests.util.ConverterTestCase import ConverterTestCase
 from urdf_usd_converter._impl.urdf_parser.parser import URDFParser
 
@@ -60,16 +63,6 @@ class TestURDFParser(ConverterTestCase):
         with self.assertRaisesRegex(RuntimeError, r".*rgba: Invalid value: 0.0 1.0 \(line: 5\).*"):
             parser.parse()
 
-    def test_load_error_different_place(self):
-        # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_different_place.urdf")
-        parser = URDFParser(model_path)
-
-        with self.assertRaisesRegex(
-            RuntimeError, r".*geometry: Invalid element type. This uses a reserved tag, but in the wrong place \(line: 8\).*"
-        ):
-            parser.parse()
-
     def test_load_error_no_material_name(self):
         # Load the specified URDF file.
         model_path = pathlib.Path("tests/data/error_no_material_name.urdf")
@@ -78,12 +71,18 @@ class TestURDFParser(ConverterTestCase):
         with self.assertRaisesRegex(RuntimeError, r".*material: name is required \(line: 4\).*"):
             parser.parse()
 
-    def test_load_error_no_mesh_filename(self):
+    def test_load_warning_no_mesh_filename(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_no_mesh_filename.urdf")
+        model_path = pathlib.Path("tests/data/warning_no_mesh_filename.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*mesh: Filename is required \(line: 8\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*mesh: Filename is required.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
     def test_load_error_duplicate_material_names(self):
@@ -110,36 +109,62 @@ class TestURDFParser(ConverterTestCase):
         with self.assertRaisesRegex(RuntimeError, r".*joint: Joint name 'JointA' already exists \(line: 36\).*"):
             parser.parse()
 
-    def test_load_error_invalid_material_name(self):
+    def test_load_warning_invalid_material_name(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_invalid_material_name.urdf")
+        model_path = pathlib.Path("tests/data/warning_invalid_material_name.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*Material name 'green' not found \(line: 13\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Material name 'green' not found.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
-    def test_load_error_missing_visual_geometry(self):
+    def test_load_warning_missing_visual_geometry(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_missing_visual_geometry.urdf")
+        model_path = pathlib.Path("tests/data/warning_missing_visual_geometry.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*Geometry must have one of the following: box, sphere, cylinder, or mesh \(line: 6\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Geometry must have one of the following: box, sphere, cylinder, or mesh.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
-    def test_load_error_incorrect_visual_geometry_name(self):
+    def test_load_warning_incorrect_visual_geometry_name(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_incorrect_visual_geometry_name.urdf")
+        model_path = pathlib.Path("tests/data/warning_incorrect_visual_geometry_name.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*foo: Invalid geometry type \(line: 7\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*foo: Invalid geometry type.*"),
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*material: link: Material name 'green' not found.*"),
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Geometry must have one of the following: box, sphere, cylinder, or mesh.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
-    def test_load_error_missing_collision_geometry(self):
+    def test_load_warning_missing_collision_geometry(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_missing_collision_geometry.urdf")
+        model_path = pathlib.Path("tests/data/warning_missing_collision_geometry.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*Geometry must have one of the following: box, sphere, cylinder, or mesh \(line: 11\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Geometry must have one of the following: box, sphere, cylinder, or mesh.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
     def test_load_error_incorrect_joint_child_link_name(self):
@@ -166,12 +191,18 @@ class TestURDFParser(ConverterTestCase):
         with self.assertRaisesRegex(RuntimeError, r".*joint: Type is required \(line: 22\).*"):
             parser.parse()
 
-    def test_load_error_no_joint_k_velocity(self):
+    def test_load_warning_no_joint_k_velocity(self):
         # Load the specified URDF file.
-        model_path = pathlib.Path("tests/data/error_no_joint_k_velocity.urdf")
+        model_path = pathlib.Path("tests/data/warning_no_joint_k_velocity.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*safety_controller: k_velocity is required \(line: 26\).*"):
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*safety_controller: k_velocity is required.*"),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
     def test_load_error_no_joint_mimic_joint(self):
@@ -220,6 +251,18 @@ class TestURDFParser(ConverterTestCase):
         parser = URDFParser(model_path)
 
         with self.assertRaisesRegex(RuntimeError, r".*axis: Axis xyz cannot be \(0, 0, 0\) \(line: 25\).*"):
+            parser.parse()
+
+    def test_load_warning_different_place(self):
+        # Load the specified URDF file.
+        model_path = pathlib.Path("tests/data/warning_different_place.urdf")
+        parser = URDFParser(model_path)
+
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*geometry: Invalid element type. This uses a reserved tag, but in the wrong place.*")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
             parser.parse()
 
     def test_has_no_material(self):

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -14,6 +14,7 @@ from .urdf_parser.elements import (
     ElementCollision,
     ElementInertia,
     ElementLink,
+    ElementMesh,
     ElementVisual,
 )
 from .utils import (
@@ -58,8 +59,16 @@ def convert_link(parent: Usd.Prim, link: ElementLink, data: ConversionData) -> U
     apply_inertial(link_prim, link, data)
 
     # Create visual or collision geometry.
-    geometries: list[ElementVisual | ElementCollision] = [visual for visual in link.visuals if visual.geometry and visual.geometry.shape] + [
-        collision for collision in link.collisions if collision.geometry and collision.geometry.shape
+    geometries: list[ElementVisual | ElementCollision] = [
+        visual
+        for visual in link.visuals
+        if visual.geometry and visual.geometry.shape and (not isinstance(visual.geometry.shape, ElementMesh) or visual.has_mesh_filename())
+    ] + [
+        collision
+        for collision in link.collisions
+        if collision.geometry
+        and collision.geometry.shape
+        and (not isinstance(collision.geometry.shape, ElementMesh) or collision.has_mesh_filename())
     ]
 
     names = [get_geometry_name(geometry_base) for geometry_base in geometries]

--- a/urdf_usd_converter/_impl/mesh_cache.py
+++ b/urdf_usd_converter/_impl/mesh_cache.py
@@ -29,7 +29,7 @@ class MeshCache:
 
         # Store the name and safe name using the mesh path as the key.
         for mesh in meshes:
-            if mesh[0] not in self.mesh_names:
+            if mesh[0] and mesh[0] not in self.mesh_names:
                 name = pathlib.Path(mesh[0]).stem
                 safe_name = name_cache.getPrimName(geo_scope, name)
                 self.mesh_names[mesh[0]] = {"name": name, "safe_name": safe_name}

--- a/urdf_usd_converter/_impl/urdf_parser/elements.py
+++ b/urdf_usd_converter/_impl/urdf_parser/elements.py
@@ -307,6 +307,15 @@ class ElementVisual(ElementBase):
         self.geometry: ElementGeometry = None
         self.material: ElementMaterial | None = None
 
+    def has_mesh_filename(self) -> bool:
+        return (
+            self.geometry
+            and self.geometry.shape
+            and isinstance(self.geometry.shape, ElementMesh)
+            and hasattr(self.geometry.shape, "filename")
+            and self.geometry.shape.filename
+        )
+
 
 class ElementCollision(ElementBase):
     allowed_parent_tags: ClassVar[list[str]] = ["link"]
@@ -322,6 +331,15 @@ class ElementCollision(ElementBase):
         self.origin: ElementPose | None = None
         self.geometry: ElementGeometry = None
         self.verbose: ElementVerbose | None = None
+
+    def has_mesh_filename(self) -> bool:
+        return (
+            self.geometry
+            and self.geometry.shape
+            and isinstance(self.geometry.shape, ElementMesh)
+            and hasattr(self.geometry.shape, "filename")
+            and self.geometry.shape.filename
+        )
 
 
 class ElementLink(ElementBase):


### PR DESCRIPTION
## Description

Fixes #32 

- Tags that do not conform to the URDF schema structure will now trigger warnings instead of errors.
- If mesh loading fails (file does not exist, geometry does not exist, etc.), a warning will be issued instead of an error.
- Changed from an error to a warning if the specified geometry type is not defined (not "box", "sphere", "cylinder", or "mesh").
- Changed from an error to a warning if a mesh filename is not specified.
- Changed from an error to a warning if the k_velocity attribute of a safety_controller is not specified.
- Changed from an error to a warning when a material name reference does not exist.
- Changed error to warning if no geometry is specified for visual or collision.

### URDF files for confirmation

"tests/data/warning_different_place.urdf" in this branch.

The following are also useful for reviewing this PR.  

- https://github.com/Daniella1/urdf_files_dataset/blob/main/urdf_files/matlab/robotiq2F85/urdf/robotiq2F85.urdf
- https://github.com/Daniella1/urdf_files_dataset/blob/main/urdf_files/matlab/iiwa_description/urdf/kukaIiwa7.urdf

### tests/data/warning_different_place.urdf

The following code first finds the error "Error parsing XML: material: link: Material name 'green' not found", so I changed it so that it works correctly.  
-> Changed from referencing materials to creating materials.

```xml
<material name="green" />
```
to  
```xml
<material name="green">
  <color rgba="0.0 1.0 0.0 1"/>
</material>
```

## error and warning

If an ```error``` occurs during conversion using urdf-usd-converter, the conversion itself will not be performed.  
If a ```warning``` occurs during conversion by urdf-usd-converter, the warning content will be output, but the conversion will proceed.  

|Detail|urdf-usd-converter|URDF Visualizer|ROS2(rviz2)|  
|---|---|---|---|  
|Tag placement that does not conform to URDF schema|Warning|Ignore|Ignore|  
|unsupport: transmission, gazebo, calibration, dynamics, mimic, safety_controller exists|Warning|Mimics are reflected.<br />Everything else is ignored.|ROS2 has no such limitation.|  
|If mesh conversion fails<br /> (e.g., file does not exist)|Warning|Error (*1)|Error|  
|Specifying an unsupported extension for mesh external references|Warning|Ignore|Error|  
|Links form a closed loop|Error|Ignore (*2)|Error, Abort|  
|Incorrect number of elements in attributes (rgba, rpy, xyz, etc.)|Error|No errors (*3)|No errors (*4)|  
|Root tag is not "robot"|Error|Ignore (*2)|Error, Abort|  
|Invalid geometry type (not "box", "sphere", "cylinder", or "mesh")|Warning|Ignore|Error|  
|Name attribute is missing in tags where it is required|Error|Ignore (*5)|Error, Abort|  
|Type attribute is not specified in joint|Error|Become Fixed|Error, Abort|  
|Invalid joint type attribute|Error|Become Fixed|Error, Abort|  
Filename is not specified in mesh|Warning|Ignore|Error|  
|k_velocity attribute is not specified in safety_controller|Warning|Ignore|Error, Abort|  
|Joint attribute is not specified in mimic|Error|Error|Error, Abort|  
|xyz in axis is (0, 0, 0)|Error|Ignore|Error|  
|Same name is specified for link, material, or joint|Error|Error|Error, Abort|  
|Only material name is specified and the material does not exist in the reference source (Global Material)|Warning|Ignore|Warning (*6)|  
|Parent and child elements are not specified in joint|Error|Ignore (*2)|Error, Abort|  
|Links specified in parent and child of joint do not exist|Error|Error (*1)|Error, Abort|  
|Geometry does not exist in visual or collision|Warning|Ignore|Error (*7)|  

When an error occurred in the URDF Visualizer, either no preview screen was displayed or the element with the error was ignored.  

In the case of ROS2 (rviz2), there are instances where errors occur during the loading of urdf files, resulting in a complete abort.
These have been marked as "```Error, Abort```".  
If an ```Error``` occurs when loading urdf and it is not aborted, we can continue in rviz2, but the error will be displayed on the rviz2 UI.  

*1:  
If an error is output, processing can continue, just like a warning from urdf-usd-converter.  

*2:  
There is no error, but nothing is displayed in the preview.  

*3:  
No errors are printed and the default value is used for unspecified values.  
Where a value is specified within the array, that value is used.  

```<color rgba="0.5"/>``` -> ```rgba=(0.5, 0, 0, 1)```

*4:  
No errors are printed and all values ​​are replaced with default values.  

```<color rgba="0.5"/>``` -> ```rgba=(0, 0, 0, 1)```

*5:  
No error is output, but the operation becomes unstable.  

*6:  
This warning is more lenient than an error and is ignored on rviz2.  

*7:  
An error is displayed when loading urdf, but the error is not displayed in rviz2.  
This means that the error location is ignored.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
