### PR TITLE
Added error handling for when links do not exist.

### DIFF
--- a/tests/data/error_no_link.urdf
+++ b/tests/data/error_no_link.urdf
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<robot name="error_no_link">
+  <material name="blue">
+    <color rgba="0.0 0.0 1.0 1.0"/>
+  </material>
+</robot>

--- a/tests/testConverter.py
+++ b/tests/testConverter.py
@@ -48,6 +48,15 @@ class TestConverter(ConverterTestCase):
         with self.assertRaisesRegex(ValueError, r".*Closed loop articulations are not supported.*"):
             converter.convert(input_path, output_dir)
 
+    def test_load_error_no_link(self):
+        # When no links exist within the URDF file.
+        input_path = "tests/data/error_no_link.urdf"
+        output_dir = str(pathlib.Path(self.tmpDir()) / "error_no_link")
+
+        converter = urdf_usd_converter.Converter()
+        with self.assertRaisesRegex(ValueError, r".*The link does not exist.*"):
+            converter.convert(input_path, output_dir)
+
     def test_load_warning_obj_no_exist_filename(self):
         # A non-existent obj file is specified.
 

--- a/urdf_usd_converter/_impl/link_hierarchy.py
+++ b/urdf_usd_converter/_impl/link_hierarchy.py
@@ -43,7 +43,7 @@ class LinkHierarchy:
                 self.link_tree[parent_link_name]["joints"].append(joint)
 
         # If the link tree is empty, make the first link the root.
-        if len(self.link_tree) == 0:
+        if len(self.link_tree) == 0 and len(self.root_element.links) > 0:
             link = self.root_element.links[0]
             self.link_tree[link.name] = {
                 "link": link,
@@ -56,6 +56,9 @@ class LinkHierarchy:
         Get the root link name from the link hierarchy.
         """
         links = [data["link"] for data in self.link_tree.values()]
+        if len(links) == 0:
+            raise ValueError("The link does not exist.")
+
         for link in links:
             is_child = False
             for d in self.link_tree.values():


### PR DESCRIPTION
## Description

Fixes #66 

We have implemented a feature to output the error message `Conversion failed: The link does not exist.` when an URDF file lacks links as shown below.  

```xml
<?xml version="1.0"?>
<robot name="error_no_link">
  <material name="blue">
    <color rgba="0.0 0.0 1.0 1.0"/>
  </material>
</robot>
```

## Test URDF
 
- tests/data/error_no_link.urdf
- https://github.com/Daniella1/urdf_files_dataset/blob/main/urdf_files/robotics-toolbox/val_description/model/robots/test_bench.urdf

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
