### PR TITLE
Bug fix for URDF materials with no material name

### DIFF
--- a/tests/data/material_color.urdf
+++ b/tests/data/material_color.urdf
@@ -3,9 +3,6 @@
   <material name="red">
     <color rgba="1 0 0 1"/>
   </material>
-  <material name="green">
-    <color rgba="0 1 0 1"/>
-  </material>
   <material name="opacity_half">
     <color rgba="0.2 0.5 1 0.5"/>
   </material>
@@ -23,7 +20,10 @@
       <geometry>
         <box size="0.5 0.5 0.5"/>
       </geometry>
-      <material name="green"/>
+      <!-- Directly specify unnamed materials. -->
+      <material>
+        <color rgba="0 1 0 1"/>
+      </material>
     </visual>
   </link>
   <link name="link_box_opacity_half">

--- a/tests/data/verifying_elements.urdf
+++ b/tests/data/verifying_elements.urdf
@@ -3,9 +3,6 @@
   <material name="red">
     <color rgba="1.0 0.0 0.0 1"/>
   </material>
-  <material name="green">
-    <color rgba="0.0 1.0 0.0 1"/>
-  </material>
   <material name="blue">
     <color rgba="0.0 0.0 1.0 1"/>
   </material>
@@ -44,7 +41,10 @@
       <geometry>
         <mesh filename="assets/box.obj" scale="0.5 0.6 1"/>
       </geometry>
-      <material name="green"/>
+      <!-- Directly specify unnamed materials. -->
+      <material>
+        <color rgba="0.0 1.0 0.0 1"/>
+      </material>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.5"/>
@@ -71,6 +71,18 @@
       <verbose value="verbose_data"/>
     </collision>
   </link>
+  <link name="link4">
+    <visual>
+      <geometry>
+        <cylinder radius="0.5" length="1"/>
+      </geometry>
+      <!-- Directly specify unnamed materials.  -->
+      <!-- Check for duplicates when there are multiple unnamed materials. -->
+      <material>
+        <color rgba="0.0 1.0 1.0 1"/>
+      </material>
+    </visual>
+  </link>
 
   <joint name="JointA" type="fixed">
     <parent link="BaseLink"/>
@@ -86,6 +98,11 @@
     <limit effort="30" velocity="1.0" lower="-2.2" upper="0.7" />
     <safety_controller k_velocity="10" k_position="15" soft_lower_limit="-2.0" soft_upper_limit="0.5" />
     <mimic joint="JointA" multiplier="2.0" offset="1.0"/>
+  </joint>
+  <joint name="JointC" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 2"/>
+    <parent link="link3"/>
+    <child link="link4" />
   </joint>
 
   <transmission name="simple_trans">

--- a/tests/testMaterial.py
+++ b/tests/testMaterial.py
@@ -43,17 +43,17 @@ class TestMaterial(ConverterTestCase):
         opacity = self.get_material_opacity(red_material)
         self.assertEqual(opacity, 1.0)
 
-        green_material_prim = material_scope_prim.GetChild("green")
-        self.assertTrue(green_material_prim.IsValid())
-        self.assertTrue(green_material_prim.IsA(UsdShade.Material))
+        unnamed_material_prim = material_scope_prim.GetChild("material_1")
+        self.assertTrue(unnamed_material_prim.IsValid())
+        self.assertTrue(unnamed_material_prim.IsA(UsdShade.Material))
 
-        green_material = UsdShade.Material(green_material_prim)
-        self.assertTrue(green_material)
-        self.assertTrue(green_material.GetPrim().HasAuthoredReferences())
+        unnamed_material = UsdShade.Material(unnamed_material_prim)
+        self.assertTrue(unnamed_material)
+        self.assertTrue(unnamed_material.GetPrim().HasAuthoredReferences())
 
-        diffuse_color = self.get_material_diffuse_color(green_material)
+        diffuse_color = self.get_material_diffuse_color(unnamed_material)
         self.assertEqual(diffuse_color, Gf.Vec3f(0, 1, 0))
-        opacity = self.get_material_opacity(green_material)
+        opacity = self.get_material_opacity(unnamed_material)
         self.assertEqual(opacity, 1.0)
 
         opacity_half_material_prim = material_scope_prim.GetChild("opacity_half")
@@ -92,7 +92,7 @@ class TestMaterial(ConverterTestCase):
         box_prim = link_box_green_prim.GetChild("box")
         self.assertTrue(box_prim.IsValid())
         self.assertTrue(box_prim.IsA(UsdGeom.Cube))
-        self.check_material_binding(box_prim, green_material)
+        self.check_material_binding(box_prim, unnamed_material)
 
         link_box_opacity_half_prim = link_box_green_prim.GetChild("link_box_opacity_half")
         self.assertTrue(link_box_opacity_half_prim.IsValid())

--- a/urdf_usd_converter/_impl/geometry.py
+++ b/urdf_usd_converter/_impl/geometry.py
@@ -50,8 +50,8 @@ def convert_geometry(parent: Usd.Prim, name: str, safe_name: str, geometry: Elem
     if isinstance(geometry, ElementVisual):
         if isinstance(geometry.geometry.shape, ElementMesh):
             bind_mesh_material(prim.GetPrim(), geometry.geometry.shape.filename, data)
-        if geometry.material and geometry.material.name:
-            bind_material(prim.GetPrim(), None, geometry.material.name, data)
+        if geometry.material and geometry.material.unique_name:
+            bind_material(prim.GetPrim(), None, geometry.material.unique_name, data)
 
     return prim
 

--- a/urdf_usd_converter/_impl/material.py
+++ b/urdf_usd_converter/_impl/material.py
@@ -486,8 +486,8 @@ def bind_material(geom_prim: Usd.Prim, mesh_file_path: pathlib.Path | None, mate
         # Get the texture from the material.
         materials = data.urdf_parser.get_materials()
         for material in materials:
-            if material[0] == material_name:
-                if material[2]:
+            if material["unique_name"] == material_name:
+                if material["file_path"]:
                     Tf.Warn(f"Textures are not projection mapped for Cube, Sphere, and Cylinder: {geom_prim.GetPath()}")
                 break
 

--- a/urdf_usd_converter/_impl/material_cache.py
+++ b/urdf_usd_converter/_impl/material_cache.py
@@ -117,16 +117,16 @@ class MaterialCache:
         materials = data.urdf_parser.get_materials()
         for material in materials:
             material_data = MaterialData()
-            material_data.name = material[0]
-            material_data.diffuse_color = Gf.Vec3f(*material[1][:3])
-            material_data.opacity = material[1][3]
+            material_data.name = material["unique_name"]  # Unique name
+            material_data.diffuse_color = Gf.Vec3f(*material["color"][:3])
+            material_data.opacity = material["color"][3]
 
-            # material[2] is the path to the texture file.
-            if material[2]:
+            # material["file_path"] is the path to the texture file.
+            if material["file_path"]:
                 # Resolve the ROS package paths.
                 # If the path is not a ROS package, it will return the original path.
                 # It also converts the path to a relative path based on the urdf file.
-                material_data.diffuse_texture_path = resolve_ros_package_paths(material[2], data)
+                material_data.diffuse_texture_path = resolve_ros_package_paths(material["file_path"], data)
 
             material_data_list.append(material_data)
 

--- a/urdf_usd_converter/_impl/ros_package.py
+++ b/urdf_usd_converter/_impl/ros_package.py
@@ -73,7 +73,7 @@ def search_ros_packages(urdf_parser: URDFParser) -> dict[str]:
             package_filenames.append(filename)
 
     for material in materials:
-        filename = material[2]
+        filename = material["file_path"]
         if filename and filename.startswith("package://"):
             package_filenames.append(filename)
 

--- a/urdf_usd_converter/_impl/urdf_parser/elements.py
+++ b/urdf_usd_converter/_impl/urdf_parser/elements.py
@@ -272,6 +272,9 @@ class ElementMaterial(ElementBase):
         # attributes.
         self.name: str | None = None
 
+        # This is the unique name to give to a material if name is empty after scanning all materials.
+        self.unique_name: str | None = None
+
         # elements.
         self.color: ElementColor | None = None
         self.texture: ElementTexture | None = None


### PR DESCRIPTION
## Description

Fixes #75 

Fixed a bug where materials were not assigned correctly when specifying materials directly to link-visual in URDF files without providing a material name.  

Before the fix, it was failing in the following pattern:  

```xml
  <link name="link_box_green">
    <visual>
      <geometry>
        <box size="0.5 0.5 0.5"/>
      </geometry>
      <!-- Directly specify unnamed materials. -->
      <material>
        <color rgba="0 1 0 1"/>
      </material>
    </visual>
  </link>
```

When the name attribute is absent in <material>, we automatically assigned unique names such as "material_1" and "material_2" to address this.  

## Unit tests

- URDF: tests/data/verifying_elements.urdf
  - unit test:  tests/test_parser.py - test_get_materials, test_get_links
- URDF: tests/data/material_color.urdf 
  - unit test: tests/testMaterial.py - test_material_color

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).