### PR TITLE
Support for 'file://' external references

### DIFF
--- a/tests/data/external_reference_file.urdf
+++ b/tests/data/external_reference_file.urdf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<robot name="external_reference_file">
+  <material name="texture_material">
+    <!-- Absolute path -->
+    <!-- In unit tests, this is verified by replacing the path with one appropriate for the environment. -->
+    <texture filename="file:///home/user/urdf/assets/grid.png"/>
+  </material>
+
+  <link name="BaseLink">
+    <visual>
+      <geometry>
+        <!-- Relative path -->
+        <mesh filename="file://assets/box.obj"/>
+      </geometry>
+      <material name="texture_material"/>
+    </visual>
+  </link>
+</robot> 

--- a/tests/testExternalReferenceFileCli.py
+++ b/tests/testExternalReferenceFileCli.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+from pxr import Usd, UsdGeom, UsdShade
+
+from tests.util.ConverterTestCase import ConverterTestCase
+from urdf_usd_converter._impl.cli import run
+
+
+class TestExternalReferenceFileCli(ConverterTestCase):
+    def test_external_reference_file(self):
+        """
+        If the mesh or texture URI specifies "file:///path/to/file.png" or "file://path/to/file.png"
+        """
+        # URDF files, texture files, and mesh files are copied to the temporary directory.
+        # External references within the urdf file will have "file:///" replaced with the path to the working directory.
+        source_path = "tests/data/external_reference_file.urdf"
+        source_texture_path = "tests/data/assets/grid.png"
+        source_mesh_path = "tests/data/assets/box.obj"
+        dist_dir = self.tmpDir()
+
+        # Create an "urdf" directory in data_dir and copy the urdf and related files into it.
+        data_dir = Path(dist_dir) / "urdf"
+        data_asset_dir = data_dir / "assets"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        data_asset_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source_path, data_dir)
+        shutil.copy(source_texture_path, data_asset_dir)
+        shutil.copy(source_mesh_path, data_asset_dir)
+
+        input_path = f"{data_dir.as_posix()}/external_reference_file.urdf"
+        output_dir = self.tmpDir()
+
+        # Find <texture filename="file:///home/user/urdf/assets/grid.png"/> in the URDF at input_path,
+        # and, filename will be replaced with the absolute path specific to each OS.
+        source_texture_path = "file:///home/user/urdf/assets/grid.png"
+        target_texture_path = f"file:///{data_dir.as_posix()}/assets/grid.png" if os.name == "nt" else f"file://{data_dir.as_posix()}/assets/grid.png"
+
+        with Path.open(input_path) as file:
+            content = file.read()
+            content = content.replace(source_texture_path, target_texture_path)
+            with Path.open(input_path, "w") as file:
+                file.write(content)
+
+        # Convert the URDF file to USD.
+        with patch("sys.argv", ["urdf_usd_converter", input_path, output_dir]):
+            self.assertEqual(run(), 0, f"Failed to convert {input_path}")
+
+        # Check the USD file after converting external_reference_file.urdf.
+        usd_path = Path(output_dir) / "external_reference_file.usda"
+        self.assertTrue(usd_path.exists())
+
+        self.stage: Usd.Stage = Usd.Stage.Open(str(usd_path))
+        self.assertIsValidUsd(self.stage)
+
+        default_prim = self.stage.GetDefaultPrim()
+        geometry_scope_prim = self.stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        # Check the mesh reference.
+        base_link_prim = geometry_scope_prim.GetChild("BaseLink")
+        self.assertTrue(base_link_prim.IsValid())
+        base_link_box_prim = base_link_prim.GetChild("box")
+        self.assertTrue(base_link_box_prim.IsValid())
+        self.assertTrue(base_link_box_prim.IsA(UsdGeom.Mesh))
+        self.assertTrue(base_link_box_prim.HasAuthoredReferences())
+
+        # Check material.
+        material_scope_prim = default_prim.GetChild("Materials")
+        self.assertTrue(material_scope_prim.IsValid())
+        texture_material_prim = material_scope_prim.GetChild("texture_material")
+        self.assertTrue(texture_material_prim.IsValid())
+        self.assertTrue(texture_material_prim.IsA(UsdShade.Material))
+        texture_material = UsdShade.Material(texture_material_prim)
+        self.assertTrue(texture_material.GetPrim().HasAuthoredReferences())
+        texture_path = self.get_material_texture_path(texture_material, "diffuseColor")
+        self.assertEqual(texture_path, Path("./Textures/grid.png"))

--- a/urdf_usd_converter/_impl/ros_package.py
+++ b/urdf_usd_converter/_impl/ros_package.py
@@ -14,6 +14,7 @@ __all__ = ["resolve_ros_package_paths", "search_ros_packages"]
 def resolve_ros_package_paths(uri: str, data: ConversionData) -> pathlib.Path:
     """
     Resolve the ROS package paths for the given filename.
+    "file://" specifications are also converted here.
 
     Args:
         uri: The path to resolve (Material textures, mesh paths).
@@ -25,11 +26,12 @@ def resolve_ros_package_paths(uri: str, data: ConversionData) -> pathlib.Path:
     if uri in data.resolved_file_paths:
         return data.resolved_file_paths[uri]
 
-    if "://" in uri and not uri.startswith("package://"):
+    if "://" in uri and not uri.startswith("package://") and not uri.startswith("file://"):
         protocol = uri.partition("://")[0]
         Tf.Warn(f"'{protocol}' is not supported: {uri}")
         resolved_path = pathlib.Path()
 
+    # if ros package URI, resolve the path.
     elif uri.startswith("package://"):
         package_name, relative_path = _split_package_name_and_path(uri)
         if not package_name or not relative_path:
@@ -41,6 +43,12 @@ def resolve_ros_package_paths(uri: str, data: ConversionData) -> pathlib.Path:
 
             if resolved_path != pathlib.Path(uri):
                 Tf.Status(f"Resolved ROS package path: {uri} -> {resolved_path}")
+
+    # if file URI, get the file path.
+    elif uri.startswith("file://"):
+        resolved_path = _get_file_path(uri)
+
+    # if other URI, use as-is.
     else:
         resolved_path = pathlib.Path(uri)
 
@@ -126,3 +134,24 @@ def _split_package_name_and_path(uri: str) -> tuple[str, pathlib.Path]:
     package_name = split_dirs[0]
     relative_path = pathlib.Path(*split_dirs[1:])
     return package_name, relative_path
+
+
+def _get_file_path(uri: str) -> pathlib.Path:
+    """
+    Get the file path from the URI.
+
+    Args:
+        uri: The URI to get the file path from.
+
+    Returns:
+        The file path.
+    """
+    # Absolute path (file:///).
+    # If drive letter (e.g. "C:") is present, use as-is; otherwise prepend "/".
+    if uri.startswith("file:///"):
+        file_path = uri.removeprefix("file:///")
+        return pathlib.Path(file_path if ":" in file_path else f"/{file_path}")
+
+    # Relative path.
+    file_path = pathlib.Path(uri.replace("file://", ""))
+    return pathlib.Path(file_path)

--- a/urdf_usd_converter/_impl/ros_package.py
+++ b/urdf_usd_converter/_impl/ros_package.py
@@ -153,5 +153,4 @@ def _get_file_path(uri: str) -> pathlib.Path:
         return pathlib.Path(file_path if ":" in file_path else f"/{file_path}")
 
     # Relative path.
-    file_path = pathlib.Path(uri.replace("file://", ""))
-    return pathlib.Path(file_path)
+    return pathlib.Path(uri.replace("file://", ""))


### PR DESCRIPTION
## Description

Fixes #91 

Support for URIs starting with `files://` has been added for specifying external references in URDF.  

### Absolute path specification

- Windows: `file:///`C:/foo/robot/meshes/part.stl -> 'C:/foo/robot/meshes/part.stl'
- Linux: `file:///`home/user/robot/meshes/part.stl -> '/home/user/robot/meshes/part.stl'

### Relative Path Specification

- Windows: `file://`meshes/part.stl -> 'meshes/part.stl'
- Linux: `file://`meshes/part.stl -> 'meshes/part.stl'

## Unit tests

- URDF: tests/data/external_reference_file.urdf
- Unit test: tests/testExternalReferenceFileCli.py

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
