### PR TITLE
Updated the newton-usd-schemas to 0.4.0.  NewtonJointAPI: damping, friction, velocityLimit

### DIFF
--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -148,7 +148,7 @@ The following table describes concept mappings between URDF and USD. All URDF co
 | [link/collision](#linkcollision) | Various `UsdGeomGPrims`,<br>`UsdReference` (for meshes),<br>`UsdPhysicsCollisionAPI`,<br>`UsdPhysicsMeshCollisionAPI` | Defines collision geometry & physical properties of the link |
 | [geometry](#geometry) | Various `UsdGeomGPrims`,<br>`UsdReference` (for meshes) | Defines the geometry for visuals and collisions |
 | [material](#material)  | `UsdShadeMaterial`,<br>`UsdShadeShaders`,<br>***GAP*** (projection shaders) | Defines the rendered appearance of the link (not the physical properties) |
-| [joint](#joint) | Various `UsdPhysicsJoints`,<br>`UsdGeomXformOps` (for the child link),<br>`NewtonMimicAPI`,<br>***GAP*** (calibration, friction, damping, soft limits) | A joint for connecting two links as well as 3D transformation for the child link. |
+| [joint](#joint) | Various `UsdPhysicsJoints`,<br>`UsdGeomXformOps` (for the child link),<br>`NewtonMimicAPI`,<br>`NewtonJointAPI`,<br>***GAP*** (calibration, effort, soft limits) | A joint for connecting two links as well as 3D transformation for the child link. |
 | [transmission](#transmission) | N/A<br>(could be `UsdPhysicsDriveAPI` if it was fully specified) | Defines the mechanical transmission mechanism between actuators and joints, but is not well specified in URDF and therefore cannot map to USD. See [Custom Elements](#custom-elements). |
 | [gazebo](#gazebo) | N/A | URDF extensions specific to the Gazebo simulator. Not a generalizable URDF element. See [Custom Elements](#custom-elements). |
 | sensor (deprecated) | N/A  | Implemented in URDF Dom but unsupported & unmaintained. See [urdf/XML/sensor](https://wiki.ros.org/urdf/XML/sensor) for details. See [Custom Elements](#custom-elements). |
@@ -746,6 +746,8 @@ In USD the two concepts are separated. The 3D frame of the child link needs to b
 
 It is important to maintain the order of link relationships for consistent conversion of the URDF kinematic tree to USD. It is recommended to author the parent link as the “Body0” relationship, and the child link as the “Body1” relationship. This 0/1 naming will correspond to various other attributes of `UsdPhysicsJoint`.
 
+When converting URDF to USD with Newton USD Schemas, `NewtonJointAPI` may additionally be applied to `PhysicsJoint` prims to author passive joint dynamics (`newton:damping`, `newton:friction`) and velocity limits (`newton:velocityLimit`). See [dynamics](#element-dynamics) and [limit](#element-limit) for unit conversion details.
+
 #### Joint Hierarchy
 
 As joints in USD are not expressed hierarchically, they can be authored anywhere within the USD prim hierarchy. For legibility & navigability, it is recommended to author the joints under a common Scope prim within the default prim (e.g. /Robot/Physics/Joint1) rather than alongside the bodies.
@@ -782,10 +784,10 @@ URDF joints have several child elements, some of which are required while others
 | [child](#element-child) | `physics:body1` | Child link |
 | [origin](#element-origin-1) | `physics:localPos0`,<br>`physics:localPos1`,<br>`physics:localRot0`,<br>`physics:localRot1`,<br><br>Also affects XformOps of the child link | Position and orientation of the child link relative to the parent link |
 | [axis](#element-axis) | `physics:axis` | The joint's axis of motion. |
-| [limit](#element-limit) | `physics:lowerLimit`,<br>`physics:upperLimit` | Physical limits of certain joints |
+| [limit](#element-limit) | `physics:lowerLimit`,<br>`physics:upperLimit`,<br>`NewtonJointAPI` (`newton:velocityLimit`) | Physical limits of certain joints |
 | [mimic](#element-mimic) | `NewtonMimicAPI` | Mimicking the behavior of other joints |
 | [calibration](#element-calibration) | ***GAP*** | Calibration information for the joint |
-| [dynamics](#element-dynamics) | ***GAP*** | Friction and damping for the joint |
+| [dynamics](#element-dynamics) | `NewtonJointAPI` | Friction and damping for the joint |
 | [safety\_controller](#element-safety_controller) | ***GAP*** | Safety control of the joint |
 
 ##### Element: parent
@@ -837,13 +839,13 @@ To account for the arbitrary axis, it is necessary to also author `physics:local
 
 The joint/limit element specifies hard limits for revolute and prismatic joints, but is not used for the other types of joints. See also [safety\_controller](#element-safety_controller) for soft limits.
 
-In USD, these joints do have lower & upper limits, but do not have effort & velocity limits. See [Appendix C](#appendix-c-filling-concept-gaps) for possible solutions.
+In USD, these joints have lower and upper position limits via UsdPhysics. The velocity attribute has no UsdPhysics equivalent, but maps to `NewtonJointAPI` `newton:velocityLimit` on the `PhysicsJoint` prim. The effort attribute remains a ***GAP***.
 
 | URDF | OpenUSD | Description |
 | :---- | :---- | :---- |
 | lower | `physics:lowerLimit` | minimum position/angle |
 | upper | `physics:upperLimit` | maximum position/angle |
-| velocity | ***GAP*** | maximum velocity (rad/s or m/s) |
+| velocity | `newton:velocityLimit` | maximum joint velocity. Revolute and continuous joints use rad/s in URDF and deg/s in NewtonJointAPI; prismatic joints use m/s in URDF and distance/s in NewtonJointAPI with no conversion (see [Linear Units](#linear-units)). |
 | effort | ***GAP*** | maximum torque/force (Nm/N) |
 
 ##### Element: mimic
@@ -873,12 +875,12 @@ This concept does not exist in USD. See [Appendix C](#appendix-c-filling-concept
 
 The joint/dynamics element defines friction and damping values for the joint, similar to a passive spring on the joint.
 
-In USD, joints do not have any passive spring mechanism. See [Appendix C](#appendix-c-filling-concept-gaps) for possible solutions.
+In USD, UsdPhysics joints do not have passive damping or friction. In Newton USD Schemas, `NewtonJointAPI` applied to the `PhysicsJoint` prim maps these attributes.
 
 | URDF | OpenUSD | Description |
 | :---- | :---- | :---- |
-| damping | ***GAP*** | motion damping of the joint ( N∙m∙s/rad or N∙s/m) |
-| friction | ***GAP*** | static friction of the joint (N∙m or N) |
+| damping | `newton:damping` | velocity-proportional damping. Revolute and continuous joints use N·m·s/rad in URDF; NewtonJointAPI uses effort·s/deg, so the per-radian coefficient is rescaled to per-degree. Prismatic joints use N·s/m in URDF and effort·s/distance in NewtonJointAPI with no conversion. |
+| friction | `newton:friction` | Coulomb friction effort opposing joint motion (N·m for revolute joints, N for prismatic joints) |
 
 ##### Element: safety\_controller
 
@@ -1034,7 +1036,7 @@ All of the UsdPhysics schemas are applied API Schemas. For example, to author a 
 
 ```
 def Cube "MyCube" (
-  prepend apiSchemas = [“PhysicsRigidBodyAPI”, “PhysicsMassAPI”]
+  prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
 )
 {
   float physics:mass = 10.0
@@ -1233,7 +1235,7 @@ def Scope "foo"
 
 It is recommended that parameters defined in the URDF but not supported in USD be stored as custom attributes on the parent `UsdPrim`.
 
-For example, parameters within a joint ([calibration](#element-calibration), [dynamics](#element-dynamics), [safety_controller](#element-safety_controller)) can be stored as custom attributes of `UsdPhysicsJoints`.
+For example, parameters within a joint ([calibration](#element-calibration), [safety_controller](#element-safety_controller), [limit](#element-limit) effort) can be stored as custom attributes of `UsdPhysicsJoints`.
 
 ```
 <joint name="foo" type="fixed">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "usd-exchange>=2.2.2",
-    "newton-usd-schemas>=0.3.1",
+    "newton-usd-schemas>=0.4.0",
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
     "pycollada>=0.9.2",

--- a/tests/data/prismatic_joints.urdf
+++ b/tests/data/prismatic_joints.urdf
@@ -77,6 +77,7 @@
     <parent link="Arm_3"/>
     <child link="Arm_4"/>
     <axis xyz="1 0 0"/>
+    <dynamics damping="0.02" friction="0.03"/>
     <limit lower="0" upper="0.5" effort="0.03" velocity="0.01"/>
   </joint>
 

--- a/tests/data/revolute_joints.urdf
+++ b/tests/data/revolute_joints.urdf
@@ -69,6 +69,7 @@
     <parent link="Arm_3"/>
     <child link="Arm_4"/>
     <axis xyz="0 1 0"/>
+    <dynamics damping="1.0" friction="0.5"/>
     <limit lower="-0.3" upper="0.5" effort="0.01" velocity="0.02"/>
   </joint>
 

--- a/tests/data/undefined.urdf
+++ b/tests/data/undefined.urdf
@@ -56,9 +56,6 @@
     <!-- calibration is currently not supported, so it is stored as custom attributes. -->
     <calibration rising="0.3" falling="0.2" reference_position="0.1"/>
 
-    <!-- dynamics is currently not supported, so it is stored as custom attributes. -->
-    <dynamics damping="0.0" friction="0.0"/>
-
     <!-- safety_controller is currently not supported, so it is stored as custom attributes. -->
     <safety_controller k_velocity="10" k_position="15" soft_lower_limit="-2.0" soft_upper_limit="0.5" />
   </joint>

--- a/tests/testJoints.py
+++ b/tests/testJoints.py
@@ -57,7 +57,7 @@ class TestJoints(ConverterTestCase):
 
         # Custom attributes. This joint does not have a limit specified.
         self.assertFalse(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertFalse(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
+        self.assertFalse(revolute_joint.GetPrim().HasAPI("NewtonJointAPI"))
 
         # Joint_arm_1.
         physics_revolute_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_1"))
@@ -74,15 +74,14 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(revolute_joint.GetLowerLimitAttr().Get(), 0.0, places=6)
         self.assertAlmostEqual(revolute_joint.GetUpperLimitAttr().Get(), 17.188734, places=6)
 
-        # Custom attributes.
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.0, places=6)
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.0, places=6)
-
-        # Joint_arm_2.
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = revolute_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.0, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), 0.0, places=6)
         physics_revolute_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_2"))
         self.assertTrue(physics_revolute_joint_prim.IsValid())
         self.assertTrue(physics_revolute_joint_prim.IsA(UsdPhysics.RevoluteJoint))
@@ -97,13 +96,14 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(revolute_joint.GetLowerLimitAttr().Get(), -17.188734, places=6)
         self.assertAlmostEqual(revolute_joint.GetUpperLimitAttr().Get(), 0.0, places=6)
 
-        # Custom attributes.
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.0, places=6)
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.0, places=6)
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = revolute_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.0, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), 0.0, places=6)
 
         # Joint_arm_3.
         physics_revolute_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_3"))
@@ -120,13 +120,18 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(revolute_joint.GetLowerLimitAttr().Get(), -17.188734, places=6)
         self.assertAlmostEqual(revolute_joint.GetUpperLimitAttr().Get(), 28.64789, places=6)
 
-        # Custom attributes.
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.01, places=6)
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.02, places=6)
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = revolute_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.01, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), math.degrees(0.02), places=6)
+        self.assertTrue(joint_prim.GetAttribute("newton:damping").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:damping").Get(), 1.0 * math.pi / 180.0, places=6)
+        self.assertTrue(joint_prim.GetAttribute("newton:friction").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:friction").Get(), 0.5, places=6)
 
     def test_fixed_continuous_joints(self):
         input_path = "tests/data/fixed_continuous_joints.urdf"
@@ -176,7 +181,7 @@ class TestJoints(ConverterTestCase):
 
         # Custom attributes. This joint does not have a limit specified.
         self.assertFalse(revolute_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertFalse(revolute_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
+        self.assertFalse(revolute_joint.GetPrim().HasAPI("NewtonJointAPI"))
 
     def test_fixed_prismatic_joints(self):
         input_path = "tests/data/prismatic_joints.urdf"
@@ -214,7 +219,7 @@ class TestJoints(ConverterTestCase):
 
         # Custom attributes. This joint does not have a limit specified.
         self.assertFalse(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertFalse(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
+        self.assertFalse(prismatic_joint.GetPrim().HasAPI("NewtonJointAPI"))
 
         # Joint_arm_1.
         physics_prismatic_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_1"))
@@ -231,13 +236,14 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(prismatic_joint.GetLowerLimitAttr().Get(), 0.0, places=6)
         self.assertAlmostEqual(prismatic_joint.GetUpperLimitAttr().Get(), 0.5, places=6)
 
-        # Custom attributes.
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.01, places=6)
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.0, places=6)
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = prismatic_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.01, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), 0.0, places=6)
 
         # Joint_arm_2.
         physics_prismatic_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_2"))
@@ -254,13 +260,14 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(prismatic_joint.GetLowerLimitAttr().Get(), -0.2, places=6)
         self.assertAlmostEqual(prismatic_joint.GetUpperLimitAttr().Get(), 0.0, places=6)
 
-        # Custom attributes.
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.02, places=6)
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.01, places=6)
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = prismatic_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.02, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), 0.01, places=6)
 
         # Joint_arm_3.
         physics_prismatic_joint_prim = stage.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_arm_3"))
@@ -277,13 +284,18 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(prismatic_joint.GetLowerLimitAttr().Get(), 0.0, places=6)
         self.assertAlmostEqual(prismatic_joint.GetUpperLimitAttr().Get(), 0.5, places=6)
 
-        # Custom attributes.
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:effort").Get(), 0.03, places=6)
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").HasAuthoredValue())
-        self.assertTrue(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").IsCustom())
-        self.assertAlmostEqual(prismatic_joint.GetPrim().GetAttribute("urdf:limit:velocity").Get(), 0.01, places=6)
+        # Custom attributes and NewtonJointAPI.
+        joint_prim = prismatic_joint.GetPrim()
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").HasAuthoredValue())
+        self.assertTrue(joint_prim.GetAttribute("urdf:limit:effort").IsCustom())
+        self.assertAlmostEqual(joint_prim.GetAttribute("urdf:limit:effort").Get(), 0.03, places=6)
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:velocityLimit").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:velocityLimit").Get(), 0.01, places=6)
+        self.assertTrue(joint_prim.GetAttribute("newton:damping").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:damping").Get(), 0.02, places=6)
+        self.assertTrue(joint_prim.GetAttribute("newton:friction").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:friction").Get(), 0.03, places=6)
 
     def test_fixed_planar_joints(self):
         input_path = "tests/data/fixed_planar_joints.urdf"

--- a/tests/testPhysics.py
+++ b/tests/testPhysics.py
@@ -114,6 +114,20 @@ class TestPhysics(ConverterTestCase):
         self.assertFalse(child_prims[0].HasAPI(UsdPhysics.CollisionAPI))
         self.assertFalse(child_prims[0].HasAPI("NewtonCollisionAPI"))
 
+    def test_physics_joint_dynamics(self):
+        default_prim = self.stage.GetDefaultPrim()
+        physics_scope_prim = self.stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Physics"))
+        self.assertTrue(physics_scope_prim.IsValid())
+
+        joint_prim = physics_scope_prim.GetPrimAtPath(physics_scope_prim.GetPath().AppendChild("joint_cylinder_sphere"))
+        self.assertTrue(joint_prim.IsValid())
+        self.assertTrue(joint_prim.IsA(UsdPhysics.FixedJoint))
+        self.assertTrue(joint_prim.HasAPI("NewtonJointAPI"))
+        self.assertTrue(joint_prim.GetAttribute("newton:damping").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:damping").Get(), 0.01, places=6)
+        self.assertTrue(joint_prim.GetAttribute("newton:friction").HasAuthoredValue())
+        self.assertAlmostEqual(joint_prim.GetAttribute("newton:friction").Get(), 0.02, places=6)
+
 
 class TestPhysicsMesh(ConverterTestCase):
     def test_physics_mesh_collision(self):

--- a/tests/testUndefined.py
+++ b/tests/testUndefined.py
@@ -195,17 +195,7 @@ class TestUndefined(ConverterTestCase):
         reference_position = joint_box_prim.GetAttribute("urdf:calibration:reference_position").Get()
         self.assertAlmostEqual(reference_position, 0.1)
 
-        # Unsupported parameters: Cutstom attributes in "dynamics".
-        self.assertTrue(joint_box_prim.GetAttribute("urdf:dynamics:damping").HasAuthoredValue())
-        self.assertTrue(joint_box_prim.GetAttribute("urdf:dynamics:damping").IsCustom())
-        damping = joint_box_prim.GetAttribute("urdf:dynamics:damping").Get()
-        self.assertAlmostEqual(damping, 0.0)
-        self.assertTrue(joint_box_prim.GetAttribute("urdf:dynamics:friction").HasAuthoredValue())
-        self.assertTrue(joint_box_prim.GetAttribute("urdf:dynamics:friction").IsCustom())
-        friction = joint_box_prim.GetAttribute("urdf:dynamics:friction").Get()
-        self.assertAlmostEqual(friction, 0.0)
-
-        # Unsupported parameters: Cutstom attributes in "safety_controller".
+        # Unsupported parameters: Custom attributes in "safety_controller".
         self.assertTrue(joint_box_prim.GetAttribute("urdf:safety_controller:k_velocity").HasAuthoredValue())
         self.assertTrue(joint_box_prim.GetAttribute("urdf:safety_controller:k_velocity").IsCustom())
         k_velocity = joint_box_prim.GetAttribute("urdf:safety_controller:k_velocity").Get()

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -399,7 +399,8 @@ def _convert_joint_damping(joint_type: str, damping: float) -> float:
     which need no conversion.
     """
     if joint_type in ("revolute", "continuous"):
-        # Scale a per-radian coefficient to per-degree; not math.radians(), which converts angle values.
+        # Convert a per-radian coefficient (effort·s/rad) to per-degree (effort·s/deg) by multiplying by
+        # radians-per-degree (pi/180). Not an angle conversion, so math.radians() is intentionally avoided.
         return damping * math.pi / 180.0
     return damping
 

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -368,6 +368,7 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
             if joint.mimic and joint.mimic.joint:
                 mimic_joints_names.append(joint.name)
 
+            apply_newton_joint_api(joint, physics_joint.GetPrim())
             convert_unsupported_attributes_and_elements(joint, physics_joint.GetPrim(), data)
 
             # Store custom attributes and custom elements for the specified element.
@@ -388,6 +389,66 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
             set_physics_mimic_joint(joint, physics_joint_prim, ref_joint_prim)
 
 
+def _convert_joint_damping(joint_type: str, damping: float) -> float:
+    """
+    Convert URDF joint damping to NewtonJointAPI units.
+
+    Revolute and continuous joints use N·m·s/rad in URDF and effort·s/deg in
+    NewtonJointAPI, so the per-radian coefficient is rescaled to per-degree.
+    Prismatic joints use N·s/m in URDF and effort·s/distance in NewtonJointAPI,
+    which need no conversion.
+    """
+    if joint_type in ("revolute", "continuous"):
+        # Scale a per-radian coefficient to per-degree; not math.radians(), which converts angle values.
+        return damping * math.pi / 180.0
+    return damping
+
+
+def _convert_joint_velocity_limit(joint_type: str, velocity: float) -> float:
+    """
+    Convert URDF joint velocity limit to NewtonJointAPI units.
+
+    Revolute and continuous joints use rad/s in URDF and deg/s in NewtonJointAPI.
+    Prismatic joints use m/s in URDF and distance/s in NewtonJointAPI, which need
+    no conversion.
+    """
+    if joint_type in ("revolute", "continuous"):
+        return math.degrees(velocity)
+    return velocity
+
+
+def apply_newton_joint_api(element_joint: ElementJoint, prim: Usd.Prim):
+    """
+    Map URDF joint dynamics and velocity limits to NewtonJointAPI.
+
+    Args:
+        element_joint: ElementJoint in URDF
+        prim: PhysicsJoint in USD
+    """
+    damping = None
+    friction = None
+    velocity_limit = None
+
+    if element_joint.dynamics:
+        damping = _convert_joint_damping(element_joint.type, element_joint.dynamics.get_with_default("damping"))
+        friction = element_joint.dynamics.get_with_default("friction")
+
+    if element_joint.limit and element_joint.type in ("revolute", "continuous", "prismatic"):
+        velocity_limit = _convert_joint_velocity_limit(element_joint.type, element_joint.limit.get_with_default("velocity"))
+
+    if damping is None and friction is None and velocity_limit is None:
+        return
+
+    prim.ApplyAPI("NewtonJointAPI")
+
+    if damping is not None:
+        set_schema_attribute(prim, "newton:damping", damping)
+    if friction is not None:
+        set_schema_attribute(prim, "newton:friction", friction)
+    if velocity_limit is not None:
+        set_schema_attribute(prim, "newton:velocityLimit", velocity_limit)
+
+
 def convert_unsupported_attributes_and_elements(element_joint: ElementJoint, prim: Usd.Prim, data: ConversionData):
     """
     Unsupported attributes and elements within the joint are stored as custom attributes of the PhysicsJoint.
@@ -401,9 +462,6 @@ def convert_unsupported_attributes_and_elements(element_joint: ElementJoint, pri
         effort = element_joint.limit.get_with_default("effort")
         if effort is not None:
             prim.CreateAttribute("urdf:limit:effort", Sdf.ValueTypeNames.Float, custom=True).Set(effort)
-        velocity = element_joint.limit.get_with_default("velocity")
-        if velocity is not None:
-            prim.CreateAttribute("urdf:limit:velocity", Sdf.ValueTypeNames.Float, custom=True).Set(velocity)
 
     if element_joint.calibration:
         rising = element_joint.calibration.get_with_default("rising")
@@ -415,14 +473,6 @@ def convert_unsupported_attributes_and_elements(element_joint: ElementJoint, pri
         reference_position = element_joint.calibration.get_with_default("reference_position")
         if reference_position is not None:
             prim.CreateAttribute("urdf:calibration:reference_position", Sdf.ValueTypeNames.Float, custom=True).Set(reference_position)
-
-    if element_joint.dynamics:
-        damping = element_joint.dynamics.get_with_default("damping")
-        if damping is not None:
-            prim.CreateAttribute("urdf:dynamics:damping", Sdf.ValueTypeNames.Float, custom=True).Set(damping)
-        friction = element_joint.dynamics.get_with_default("friction")
-        if friction is not None:
-            prim.CreateAttribute("urdf:dynamics:friction", Sdf.ValueTypeNames.Float, custom=True).Set(friction)
 
     if element_joint.safety_controller:
         k_velocity = element_joint.safety_controller.get_with_default("k_velocity")

--- a/uv.lock
+++ b/uv.lock
@@ -189,11 +189,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/5d/d48294ea0f60cee4afa8d20757b9a7d2aa7b278da5b70e6070145666b460/newton_usd_schemas-0.3.1.tar.gz", hash = "sha256:18f6c03f23ffff3a4d4f313b02c70d4f925d449da2b378f1f8309cd13eb1a250", size = 66946, upload-time = "2026-06-01T17:48:49.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/12/a837c15d0ab7c8d89e67ff11fd0d071446f016ae5ff15b06b14baf5715db/newton_usd_schemas-0.4.0.tar.gz", hash = "sha256:d2706f90fdda1f1bbf66198fe41e3f4a9d3d78f86694cd882f5db4b3981383f3", size = 68824, upload-time = "2026-07-03T17:45:28.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/b6/84647196a15dbb51a530a303085b2bb9ef54084a7111755f7a33450193c5/newton_usd_schemas-0.3.1-py3-none-any.whl", hash = "sha256:bc99d8bf8fe0b51fadaca520c5b481b4ceb9c0b14f47665fdf28070d511f9524", size = 18174, upload-time = "2026-06-01T17:48:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b5/82058bdb0c64c94953d77010558700d14666ff577de2ca7e8daf8c59b306/newton_usd_schemas-0.4.0-py3-none-any.whl", hash = "sha256:212182de78191fed320631bf38b02a62467ddf77d5f43672b11758bcf2d86e47", size = 19333, upload-time = "2026-07-03T17:45:27.573Z" },
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "newton-usd-schemas", specifier = ">=0.3.1" },
+    { name = "newton-usd-schemas", specifier = ">=0.4.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "pycollada", specifier = ">=0.9.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },


### PR DESCRIPTION
## Description

Fixes #115.  

### Summary

- Updated dependency to `newton-usd-schemas>=0.4.0`.
- Added conversion for three URDF joint parameters via `NewtonJointAPI` on `PhysicsJoint` prims:
  - `joint/dynamics/@damping` → `NewtonJointAPI` `newton:damping`
  - `joint/dynamics/@friction` → `NewtonJointAPI` `newton:friction`
  - `joint/limit/@velocity` → `NewtonJointAPI` `newton:velocityLimit`
- Removed legacy custom-attribute authoring for:
  - `urdf:dynamics:damping`
  - `urdf:dynamics:friction`
  - `urdf:limit:velocity`
- Updated `docs/concept_mapping.md` to document the new `NewtonJointAPI` mappings.

### Notes on Unit Conversion

When mapping URDF joint parameters to `NewtonJointAPI`, revolute and continuous joints require unit rescaling, while prismatic joint values are passed through unchanged.

- `newton:velocityLimit`: Revolute and continuous joint velocity limits are converted from rad/s to deg/s.
- `newton:velocityLimit`: Prismatic joint velocity limits are passed through unchanged.
- `newton:damping`: Revolute and continuous joint damping values are rescaled from per-radian to per-degree.
- `newton:friction`: Prismatic joint damping and joint friction are passed through unchanged.

### Unit Test Coverage

- `tests/testJoints.py`
  - Verifies `newton:velocityLimit` for revolute joints, including rad/s → deg/s conversion.
  - Verifies `newton:velocityLimit` for prismatic joints without unit conversion.
  - Verifies `newton:damping` and `newton:friction` for revolute and prismatic joints.
- `tests/testPhysics.py`
  - Verifies `NewtonJointAPI` dynamics attributes on a fixed joint.
- `tests/testUndefined.py`
  - Removed obsolete undefined-joint coverage for damping, friction, and velocity, which are now authored through NewtonJointAPI.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
