### PR TITLE
Fix principal axes orientation extracted from the URDF inertia tensor

### DIFF
--- a/tests/data/inertia.urdf
+++ b/tests/data/inertia.urdf
@@ -83,6 +83,21 @@
     </visual>
   </link>
 
+  <link name="link_box7">
+    <inertial>
+      <origin xyz="0 0 0.5" rpy="0.3 -0.4 0.5"/>
+      <mass value="0.8"/>
+      <!-- Non-zero inertial origin rpy combined with all products of inertia; -->
+      <!-- exercises the composition of the inertial frame rotation onto the principal axes. -->
+      <inertia ixx="2.0" ixy="0.5" ixz="0.25" iyy="1.0" iyz="-0.1" izz="3.0"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.5 0.5 1.0"/>
+      </geometry>
+    </visual>
+  </link>
+
   <joint name="joint_box1_box2" type="fixed">
     <origin xyz="0 0 1.2"/>
     <parent link="link_box1"/>
@@ -107,5 +122,10 @@
     <origin xyz="0 0 1.2"/>
     <parent link="link_box5"/>
     <child link="link_box6"/>
+  </joint>
+  <joint name="joint_box6_box7" type="fixed">
+    <origin xyz="0 0 1.2"/>
+    <parent link="link_box6"/>
+    <child link="link_box7"/>
   </joint>
 </robot>

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
+import math
 import pathlib
 
+import numpy as np
 from pxr import Gf, Usd, UsdPhysics
 
 import urdf_usd_converter
@@ -15,6 +17,43 @@ class TestPhysicsInertia(ConverterTestCase):
         expected = [ixx, iyy, izz, ixy, ixz, iyz]
         for actual, expected_value in zip(inertia, expected):
             self.assertAlmostEqual(actual, expected_value, places=6)
+
+    def _assert_inertia_reconstructs(self, prim, ixx, iyy, izz, ixy, ixz, iyz, rpy=(0.0, 0.0, 0.0)):
+        """
+        The authored principal axes and diagonal inertia must reconstruct the URDF inertia tensor:
+        R(principalAxes) @ diag(diagonalInertia) @ R(principalAxes)^T == R(rpy) @ I_urdf @ R(rpy)^T
+        The rotation matrix is built from the quaternion components directly, so this check is
+        independent of the Gf matrix/vector conventions used by the converter.
+        """
+        mass_api = UsdPhysics.MassAPI(prim)
+        quat = mass_api.GetPrincipalAxesAttr().Get()
+        w = quat.GetReal()
+        x, y, z = quat.GetImaginary()
+        rotation = np.array(
+            [
+                [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+            ]
+        )
+        reconstructed = rotation @ np.diag(mass_api.GetDiagonalInertiaAttr().Get()) @ rotation.T
+
+        tensor = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]])
+        # URDF rpy is a fixed-axis (extrinsic) XYZ rotation: R = Rz(yaw) @ Ry(pitch) @ Rx(roll)
+        roll, pitch, yaw = rpy
+        cr, sr = math.cos(roll), math.sin(roll)
+        cp, sp = math.cos(pitch), math.sin(pitch)
+        cy, sy = math.cos(yaw), math.sin(yaw)
+        rotation_x = np.array([[1, 0, 0], [0, cr, -sr], [0, sr, cr]])
+        rotation_y = np.array([[cp, 0, sp], [0, 1, 0], [-sp, 0, cp]])
+        rotation_z = np.array([[cy, -sy, 0], [sy, cy, 0], [0, 0, 1]])
+        rotation_rpy = rotation_z @ rotation_y @ rotation_x
+        expected = rotation_rpy @ tensor @ rotation_rpy.T
+
+        self.assertTrue(
+            np.allclose(reconstructed, expected, atol=1e-5),
+            msg=f"reconstructed inertia tensor\n{reconstructed}\ndoes not match the URDF inertia tensor\n{expected}",
+        )
 
     def test_physics_inertia(self):
         input_path = "tests/data/inertia.urdf"
@@ -50,6 +89,7 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(1, 1, 1), 1e-6))
         self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(1, 0, 0, 0))
         self._assert_newton_inertia(link_box1_prim, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box1_prim, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
 
         # link_box2
         link_box2_prim = stage.GetPrimAtPath(link_box1_prim.GetPath().AppendChild("link_box2"))
@@ -62,8 +102,9 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(1, 1, 2), 1e-6))
-        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.5, 0.5, 0.5, 0.5))
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0.5, 0.5, 0.5, 0.5))
         self._assert_newton_inertia(link_box2_prim, 2.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box2_prim, 2.0, 1.0, 1.0, 0.0, 0.0, 0.0)
 
         # link_box3
         link_box3_prim = stage.GetPrimAtPath(link_box2_prim.GetPath().AppendChild("link_box3"))
@@ -78,6 +119,7 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(1, 2, 2), 1e-6))
         self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(1, 0, 0, 0))
         self._assert_newton_inertia(link_box3_prim, 1.0, 2.0, 2.0, 0.0, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box3_prim, 1.0, 2.0, 2.0, 0.0, 0.0, 0.0)
 
         # link_box4
         link_box4_prim = stage.GetPrimAtPath(link_box3_prim.GetPath().AppendChild("link_box4"))
@@ -90,8 +132,9 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(1, 1, 2), 1e-6))
-        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.4632976, 0.4632976, 0.5341866, 0.5341866))
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0.4632976, 0.4632976, 0.5341866, 0.5341866))
         self._assert_newton_inertia(link_box4_prim, 1.98, 1.02, 1.0, 0.14, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box4_prim, 1.98, 1.02, 1.0, 0.14, 0.0, 0.0)
 
         # link_box5
         link_box5_prim = stage.GetPrimAtPath(link_box4_prim.GetPath().AppendChild("link_box5"))
@@ -104,8 +147,9 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(1, 2, 2), 1e-6))
-        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0.9974842, 0, 0, -0.07088902))
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0.9974842, 0, 0, 0.07088902))
         self._assert_newton_inertia(link_box5_prim, 1.02, 1.98, 2.0, -0.14, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box5_prim, 1.02, 1.98, 2.0, -0.14, 0.0, 0.0)
 
         # link_box6
         link_box6_prim = stage.GetPrimAtPath(link_box5_prim.GetPath().AppendChild("link_box6"))
@@ -120,3 +164,19 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(0.79289323, 2.2071068, 3), 1e-6))
         self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0, 0.55557024, 0.8314696, 0))
         self._assert_newton_inertia(link_box6_prim, 2.0, 1.0, 3.0, 0.5, 0.0, 0.0)
+        self._assert_inertia_reconstructs(link_box6_prim, 2.0, 1.0, 3.0, 0.5, 0.0, 0.0)
+
+        # link_box7
+        link_box7_prim = stage.GetPrimAtPath(link_box6_prim.GetPath().AppendChild("link_box7"))
+        self.assertTrue(link_box7_prim.IsValid())
+        self.assertTrue(link_box7_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+        # Mass.
+        self.assertTrue(link_box7_prim.HasAPI(UsdPhysics.MassAPI))
+        mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI(link_box7_prim)
+        self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
+        self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
+        self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(0.77679752, 2.1640169, 3.0591856), 1e-6))
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.0463736, 0.2748650, 0.9481796, 0.1524932))
+        self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1)
+        self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -259,15 +259,19 @@ def extract_inertia(inertia: ElementInertia) -> tuple[Gf.Quatf, Gf.Vec3f]:
 
     # Convert eigenvector matrix (rotation matrix) to quaternion
     # Use Gf.Matrix3d to extract quaternion from rotation matrix
+    # np.linalg.eigh returns the principal axes as the *columns* of the matrix,
+    # while Gf matrices use the row-vector convention, so the Gf.Matrix3d must be
+    # filled with the transpose for ExtractRotation to yield the rotation that
+    # maps the principal frame to the link frame (I = R * diag * R^T).
     rotation_matrix = Gf.Matrix3d(
         eigenvectors[0, 0],
-        eigenvectors[0, 1],
-        eigenvectors[0, 2],
         eigenvectors[1, 0],
-        eigenvectors[1, 1],
-        eigenvectors[1, 2],
         eigenvectors[2, 0],
+        eigenvectors[0, 1],
+        eigenvectors[1, 1],
         eigenvectors[2, 1],
+        eigenvectors[0, 2],
+        eigenvectors[1, 2],
         eigenvectors[2, 2],
     )
 


### PR DESCRIPTION
## Description

Fixes #118

For any link whose URDF `<inertial>` specifies non-zero products of inertia, the authored `physics:principalAxes` was the conjugate (inverse) of the true principal-axes rotation: `R(principalAxes) @ diag(diagonalInertia) @ R^T` did not reconstruct the URDF inertia tensor (exact eigenvalues, wrong orientation), so physics consumers of the `UsdPhysics.MassAPI` values simulated wrongly oriented inertia tensors.

Root cause: `np.linalg.eigh` returns the principal axes as the *columns* of the eigenvector matrix, but `extract_inertia()` filled `Gf.Matrix3d` with it row-major. Gf matrices use the row-vector convention, so `ExtractRotation()` yielded the inverse rotation's quaternion. The fix fills the matrix with the transpose and documents the convention.

Example: a link with `ixx=0.268209 ixy=0.011284 ixz=0.0635697 iyy=0.359486 iyz=-0.00106685 izz=0.225659` authored a `principalAxes` ~94.6° away from the true principal frame (relative Frobenius error 0.375 on the reconstructed tensor); with this fix the tensor reconstructs to float precision.

Changes:
- `extract_inertia()` fills `Gf.Matrix3d` with the transposed eigenvector matrix.
- Updated the expected quaternions in `testPhysicsInertia` to the corrected convention — the conjugates of the previous values, which had encoded the defect (`link_box6` is a 180° rotation and is unchanged). The canonicalization from #90 is preserved as-is.
- Added a `link_box7` fixture combining a non-zero inertial-origin `rpy` with all products of inertia, covering the rpy composition in `apply_inertial()` (previously untested — all fixtures used `rpy="0 0 0"`).
- Added a reconstruction assertion verifying `R(principalAxes) @ diag(diagonalInertia) @ R^T` equals the URDF link-frame tensor for every fixture link. It builds the rotation matrix from the quaternion components directly, so it validates the physics independent of Gf conventions and locks the convention against regressions.

The `newton:inertia` attribute from #112 is unaffected (raw URDF values, no decomposition). All 126 unittests pass and lint is clean. Additionally validated end-to-end on a 94-link production humanoid URDF: every authored tensor now reconstructs the URDF inertia to ≤1.5e-7 relative error (float precision), where previously 28+ bodies exceeded 5% error with up to ~118° of mis-rotation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
