### PR TITLE
Modified to avoid assigning an articulation root when there are no joints

### DIFF
--- a/tests/testPhysics.py
+++ b/tests/testPhysics.py
@@ -229,3 +229,38 @@ class TestPhysicsMesh(ConverterTestCase):
         self.assertTrue(collision_box_prim.HasAPI("NewtonMeshCollisionAPI"))
         mesh_collision_api: UsdPhysics.MeshCollisionAPI = UsdPhysics.MeshCollisionAPI(collision_box_prim)
         self.assertEqual(mesh_collision_api.GetApproximationAttr().Get(), UsdPhysics.Tokens.convexHull)
+
+
+class TestPhysicsSingleRigidBody(ConverterTestCase):
+    def test_single_link_is_not_marked_as_articulation(self):
+        input_path = "tests/data/simple_box.urdf"
+        output_dir = self.tmpDir()
+
+        converter = urdf_usd_converter.Converter()
+        asset_path = converter.convert(input_path, output_dir)
+        self.assertIsNotNone(asset_path)
+        self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+
+        default_prim = stage.GetDefaultPrim()
+        self.assertTrue(default_prim.IsValid())
+
+        geometry_scope_prim = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        link_prim = stage.GetPrimAtPath(geometry_scope_prim.GetPath().AppendChild("link1"))
+        self.assertTrue(link_prim.IsValid())
+
+        # It is a rigid body.
+        self.assertTrue(link_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+        # It is not an articulation root.
+        self.assertFalse(link_prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+        self.assertFalse(link_prim.HasAPI("NewtonArticulationRootAPI"))
+
+        # No prim anywhere in the asset should be an articulation root.
+        for prim in stage.TraverseAll():
+            self.assertFalse(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+            self.assertFalse(prim.HasAPI("NewtonArticulationRootAPI"))

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -75,7 +75,10 @@ def convert_link(parent: Usd.Prim, having_articulation_root: bool, link: Element
         prim_over = data.content[Tokens.Physics].OverridePrim(link_prim.GetPath())
         UsdPhysics.RigidBodyAPI.Apply(prim_over)
 
-        if not has_root_ghost_link and not having_articulation_root:
+        # A single rigid body should not be marked as an articulation root or it will
+        # be treated as a one-link articulation instead of a free rigid body.
+        has_articulated_joints = len(data.urdf_parser.get_root_element().joints) > 0
+        if has_articulated_joints and not has_root_ghost_link and not having_articulation_root:
             # Assign ArticulationRoot to the first link.
             UsdPhysics.ArticulationRootAPI.Apply(prim_over)
             prim_over.ApplyAPI("NewtonArticulationRootAPI")


### PR DESCRIPTION
Fixes #121 

## Description

We have fixed the issue so that, in URDF, when a link is a single link and has no joints, the Articulation Root is not assigned.

## unit tests

- unit test: tests/testPhysics.py - TestPhysicsSingleRigidBody
- urdf: tests/data/simple_box.urdf

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
