### PR TITLE
Changed error messages for float3/float4 attributes.

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -52,7 +52,7 @@ class TestURDFParser(ConverterTestCase):
         model_path = pathlib.Path("tests/data/error_incorrect_vec3.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*xyz: Invalid value: -2.2 0.0 0.5 1.0 \(line: 6\).*"):
+        with self.assertRaisesRegex(RuntimeError, r".*xyz: Invalid value: Parser found 4 elements.*\[-2.2 0.0 0.5 1.0\] \(line: 6\).*"):
             parser.parse()
 
     def test_load_error_incorrect_vec4(self):
@@ -60,7 +60,7 @@ class TestURDFParser(ConverterTestCase):
         model_path = pathlib.Path("tests/data/error_incorrect_vec4.urdf")
         parser = URDFParser(model_path)
 
-        with self.assertRaisesRegex(RuntimeError, r".*rgba: Invalid value: 0.0 1.0 \(line: 5\).*"):
+        with self.assertRaisesRegex(RuntimeError, r".*rgba: Invalid value: Parser found 2 elements.*\[0.0 1.0\] \(line: 5\).*"):
             parser.parse()
 
     def test_load_error_no_material_name(self):

--- a/urdf_usd_converter/_impl/urdf_parser/parser.py
+++ b/urdf_usd_converter/_impl/urdf_parser/parser.py
@@ -157,7 +157,11 @@ class URDFParser:
         # Separated by one or more spaces or tabs.
         values = re.split(r"\s+", attr_value)
         if len(values) != 3:
-            raise ValueError(self._get_error_message(f"{name}: Invalid value: {attr_value}", element))
+            raise ValueError(
+                self._get_error_message(
+                    f"{name}: Invalid value: Parser found {len(values)} elements but 3 expected while parsing vector [{attr_value}]", element
+                )
+            )
         return (float(values[0]), float(values[1]), float(values[2]))
 
     def _convert_attribute_float4(self, element: ElementBase, name: str) -> tuple[float, float, float, float]:
@@ -171,7 +175,11 @@ class URDFParser:
         # Separated by one or more spaces or tabs.
         values = re.split(r"\s+", attr_value)
         if len(values) != 4:
-            raise ValueError(self._get_error_message(f"{name}: Invalid value: {attr_value}", element))
+            raise ValueError(
+                self._get_error_message(
+                    f"{name}: Invalid value: Parser found {len(values)} elements but 4 expected while parsing vector [{attr_value}]", element
+                )
+            )
         return (float(values[0]), float(values[1]), float(values[2]), float(values[3]))
 
     def _get_error_message(self, message: str, element: ElementBase | ET.Element) -> str:


### PR DESCRIPTION
Fixes #126 

## Description

Changed the error message displayed when specifying 3 or 4 elements as an attribute value.

## Examples

```xml
      <origin rpy="0.0 0.0" xyz="-2.2 0.0 0.5"/>
```

When specifying something other than three elements in `rpy`.  

```
Conversion failed: Error parsing XML: origin: rpy: Invalid value: Parser found 2 elements but 3 expected while parsing vector [0.0 0.0]
```

```xml
    <color rgba="0.0 0.0 1.0"/>
```

When specifying something other than four elements in `rgba`.  

```
Conversion failed: Error parsing XML: color: rgba: Invalid value: Parser found 3 elements but 4 expected while parsing vector [0.0 0.0 1.0]
```

### mesh-scale

The following is an example where only one element is specified for `scale` instead of three.  

```xml
      <geometry>
        <mesh filename="cube.obj" scale="0.00254"/>
      </geometry>
```

The following error appears when converting to USD.

```
Conversion failed: Error parsing XML: mesh: scale: Invalid value: Parser found 1 elements but 3 expected while parsing vector [0.00254]
```

## Unit tests

- tests/data/error_incorrect_vec3.urdf
- tests/data/error_incorrect_vec4.urdf

### urdf_usd_converter "tests/data/error_incorrect_vec3.urdf" "./export_usds/"

```
Conversion failed: Error parsing XML: origin: xyz: Invalid value: Parser found 4 elements but 3 expected while parsing vector [-2.2 0.0 0.5 1.0] (line: 6)
```

### urdf_usd_converter "tests/data/error_incorrect_vec4.urdf" "./export_usds/"

```
Conversion failed: Error parsing XML: color: rgba: Invalid value: Parser found 2 elements but 4 expected while parsing vector [0.0 1.0] (line: 5)
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
