### PR TITLE
Fixed a load error that occurred when material names were missing in COLLADA files

### DIFF
--- a/tests/data/assets/no_material_id.dae
+++ b/tests/data/assets/no_material_id.dae
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset><up_axis>Z_UP</up_axis></asset>
+  <library_effects>
+    <effect id="effect0"><profile_COMMON><technique sid="common"><lambert>
+      <diffuse><color>0.8 0.2 0.2 1</color></diffuse>
+    </lambert></technique></profile_COMMON></effect>
+  </library_effects>
+  <library_materials>
+    <!-- id="material0" does not exist -->
+    <material><instance_effect url="#effect0"/></material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="mesh0"><mesh>
+      <source id="pos"><float_array id="posarr" count="9">0 0 0 1 0 0 0 1 0</float_array>
+        <technique_common><accessor source="#posarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <source id="norm"><float_array id="normarr" count="9">0 0 1 0 0 1 0 0 1</float_array>
+        <technique_common><accessor source="#normarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <vertices id="verts"><input semantic="POSITION" source="#pos"/></vertices>
+      <triangles count="1">
+        <input semantic="VERTEX" source="#verts" offset="0"/>
+        <input semantic="NORMAL" source="#norm" offset="1"/>
+        <p>0 0 1 1 2 2</p>
+      </triangles>
+    </mesh></geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="scene0"><node id="node0">
+      <instance_geometry url="#mesh0" />
+    </node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene0"/></scene>
+</COLLADA>

--- a/tests/data/assets/no_normal.dae
+++ b/tests/data/assets/no_normal.dae
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset><up_axis>Z_UP</up_axis></asset>
+  <library_effects>
+    <effect id="effect0"><profile_COMMON><technique sid="common"><lambert>
+      <diffuse><color>0.2 0.8 0.2 1</color></diffuse>
+    </lambert></technique></profile_COMMON></effect>
+  </library_effects>
+  <library_materials>
+    <material id="material0" name="material0"><instance_effect url="#effect0"/></material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="mesh0"><mesh>
+      <source id="pos"><float_array id="posarr" count="9">0 0 0 1 0 0 0 1 0</float_array>
+        <technique_common><accessor source="#posarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <source id="norm"><float_array id="normarr" count="9">0 0 1 0 0 1 0 0 1</float_array>
+        <technique_common><accessor source="#normarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <vertices id="verts"><input semantic="POSITION" source="#pos"/></vertices>
+      <triangles material="mat0" count="1">
+        <input semantic="VERTEX" source="#verts" offset="0"/>
+        <!-- The normal vector is not specified here. -->
+        <p>0 1 2</p>
+      </triangles>
+    </mesh></geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="scene0"><node id="node0">
+      <instance_geometry url="#mesh0"><bind_material><technique_common>
+        <instance_material symbol="mat0" target="#material0"/>
+      </technique_common></bind_material></instance_geometry>
+    </node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene0"/></scene>
+</COLLADA>

--- a/tests/data/assets/unnamed_material.dae
+++ b/tests/data/assets/unnamed_material.dae
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset><up_axis>Z_UP</up_axis></asset>
+  <library_effects>
+    <effect id="effect0"><profile_COMMON><technique sid="common"><lambert>
+      <diffuse><color>0.8 0.2 0.2 1</color></diffuse>
+    </lambert></technique></profile_COMMON></effect>
+  </library_effects>
+  <library_materials>
+    <!-- Intentionally omit name attribute (valid COLLADA; triggers issue #127). -->
+    <material id="material0"><instance_effect url="#effect0"/></material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="mesh0"><mesh>
+      <source id="pos"><float_array id="posarr" count="9">0 0 0 1 0 0 0 1 0</float_array>
+        <technique_common><accessor source="#posarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <source id="norm"><float_array id="normarr" count="9">0 0 1 0 0 1 0 0 1</float_array>
+        <technique_common><accessor source="#normarr" count="3" stride="3">
+          <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+        </accessor></technique_common></source>
+      <vertices id="verts"><input semantic="POSITION" source="#pos"/></vertices>
+      <triangles material="mat0" count="1">
+        <input semantic="VERTEX" source="#verts" offset="0"/>
+        <input semantic="NORMAL" source="#norm" offset="1"/>
+        <p>0 0 1 1 2 2</p>
+      </triangles>
+    </mesh></geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="scene0"><node id="node0">
+      <instance_geometry url="#mesh0"><bind_material><technique_common>
+        <instance_material symbol="mat0" target="#material0"/>
+      </technique_common></bind_material></instance_geometry>
+    </node></visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#scene0"/></scene>
+</COLLADA>

--- a/tests/data/dae_no_material_id.urdf
+++ b/tests/data/dae_no_material_id.urdf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<robot name="dae_no_material_id">
+  <link name="link1">
+    <visual>
+      <geometry>
+        <mesh filename="assets/no_material_id.dae"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/tests/data/dae_no_normal.urdf
+++ b/tests/data/dae_no_normal.urdf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<robot name="dae_no_normal">
+  <link name="link1">
+    <visual>
+      <geometry>
+        <mesh filename="assets/no_normal.dae"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/tests/data/unnamed_mat.urdf
+++ b/tests/data/unnamed_mat.urdf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot name="unnamed_mat">
+  <link name="base_link">
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <mesh filename="assets/unnamed_material.dae" scale="1 1 1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/tests/testMaterial.py
+++ b/tests/testMaterial.py
@@ -935,3 +935,37 @@ class TestMaterial(ConverterTestCase):
         family_type = subset.GetFamilyType(mesh, family_name)
         self.assertEqual(family_type, UsdGeom.Tokens.partition)
         self.assertTrue(subset.ValidateFamily(mesh, element_type, family_name))
+
+    def test_dae_unnamed_material(self):
+        """COLLADA materials without a name attribute should use the material id."""
+        input_path = "tests/data/unnamed_mat.urdf"
+        output_dir = self.tmpDir()
+
+        converter = urdf_usd_converter.Converter()
+        asset_path = converter.convert(input_path, output_dir)
+
+        self.assertIsNotNone(asset_path)
+        self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+
+        default_prim = stage.GetDefaultPrim()
+        material_scope_prim = default_prim.GetChild("Materials")
+        self.assertTrue(material_scope_prim.IsValid())
+
+        material_prim = material_scope_prim.GetChild("material0")
+        self.assertTrue(material_prim.IsValid())
+        self.assertTrue(material_prim.IsA(UsdShade.Material))
+        material = UsdShade.Material(material_prim)
+
+        diffuse_color = self.get_material_diffuse_color(material)
+        diffuse_color = usdex.core.linearToSrgb(diffuse_color)
+        self.assertTrue(Gf.IsClose(diffuse_color, Gf.Vec3f(0.8, 0.2, 0.2), 1e-6))
+
+        geometry_scope_prim = default_prim.GetChild("Geometry")
+        base_link_prim = geometry_scope_prim.GetChild("base_link")
+        mesh_prim = base_link_prim.GetChild("unnamed_material")
+        self.assertTrue(mesh_prim.IsValid())
+        self.assertTrue(mesh_prim.IsA(UsdGeom.Mesh))
+        self.check_material_binding(mesh_prim, material)

--- a/tests/testMeshDae.py
+++ b/tests/testMeshDae.py
@@ -85,3 +85,35 @@ class TestMeshDae(ConverterTestCase):
                 omni.asset_validator.IssuePredicates.IsRule(omni.asset_validator.NormalsExistChecker),
             ],
         )
+
+    def test_dae_no_material_id(self):
+        input_path = "tests/data/dae_no_material_id.urdf"
+        output_dir = self.tmpDir()
+
+        converter = urdf_usd_converter.Converter()
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [
+                (
+                    Tf.TF_DIAGNOSTIC_WARNING_TYPE,
+                    ".*could not be parsed. A material cannot be identified because it has no valid ID.*",
+                ),
+            ],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset_path = converter.convert(input_path, output_dir)
+
+        self.assertIsNotNone(asset_path)
+        self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+
+        default_prim = stage.GetDefaultPrim()
+        geometry_scope_prim = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        mesh_prim = stage.GetPrimAtPath(geometry_scope_prim.GetPath().AppendChild("link1").AppendChild("no_material_id"))
+        self.assertTrue(mesh_prim.IsValid())
+        self.assertTrue(mesh_prim.IsA(UsdGeom.Xform))
+        self.assertEqual(len(mesh_prim.GetChildren()), 0)

--- a/tests/testMeshDae.py
+++ b/tests/testMeshDae.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 
+import omni.asset_validator
 import usdex.core
 import usdex.test
 from pxr import Tf, Usd, UsdGeom
@@ -48,3 +49,39 @@ class TestMeshDae(ConverterTestCase):
         # Check whether the prim for the line is not output and only one mesh exists.
         child_count = len(box_with_line_prim.GetChildren())
         self.assertEqual(child_count, 1)
+
+    def test_dae_no_normal(self):
+        # DAE mesh whose triangles do not bind NORMAL inputs should convert, but fail USD validation.
+        input_path = "tests/data/dae_no_normal.urdf"
+        output_dir = self.tmpDir()
+
+        converter = urdf_usd_converter.Converter()
+        asset_path = converter.convert(input_path, output_dir)
+
+        self.assertIsNotNone(asset_path)
+        self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+
+        default_prim = stage.GetDefaultPrim()
+        geometry_scope_prim = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        mesh_prim = stage.GetPrimAtPath(geometry_scope_prim.GetPath().AppendChild("link1").AppendChild("no_normal"))
+        self.assertTrue(mesh_prim.IsValid())
+        self.assertTrue(mesh_prim.IsA(UsdGeom.Mesh))
+
+        mesh = UsdGeom.Mesh(mesh_prim)
+        self.assertEqual(len(mesh.GetPointsAttr().Get()), 3)
+        primvars_api = UsdGeom.PrimvarsAPI(mesh_prim)
+        normals_primvar: UsdGeom.Primvar = primvars_api.GetPrimvar("normals")
+        self.assertFalse(normals_primvar.IsDefined())
+        uvs_primvar: UsdGeom.Primvar = primvars_api.GetPrimvar("st")
+        self.assertFalse(uvs_primvar.IsDefined())
+
+        self.assertIsInvalidUsd(
+            stage,
+            [
+                omni.asset_validator.IssuePredicates.IsRule(omni.asset_validator.NormalsExistChecker),
+            ],
+        )

--- a/urdf_usd_converter/_impl/conversion_collada.py
+++ b/urdf_usd_converter/_impl/conversion_collada.py
@@ -130,7 +130,7 @@ def _convert_mesh(
         face_material_names.append(material_name)
 
         # normals.
-        if hasattr(primitive, "normal") and len(primitive.normal) > 0:
+        if hasattr(primitive, "normal") and primitive.normal is not None and len(primitive.normal) > 0:
             primitive_normals = np.array(primitive.normal, dtype=np.float32).reshape(-1, 3)
             all_normals_list.append(primitive_normals)
             normal_indices = primitive.normal_index
@@ -148,13 +148,13 @@ def _convert_mesh(
             current_normal_offset += len(primitive_normals)
 
         # uvs.
-        if hasattr(primitive, "texcoordset") and len(primitive.texcoordset) > 0:
+        if hasattr(primitive, "texcoordset") and primitive.texcoordset is not None and len(primitive.texcoordset) > 0:
             uv_data = np.array(primitive.texcoordset[0], dtype=np.float32).reshape(-1, 2)
             all_uvs_list.append(uv_data)
 
             uv_indices = (
                 primitive.texcoord_indexset[0]
-                if hasattr(primitive, "texcoord_indexset") and len(primitive.texcoord_indexset) > 0
+                if hasattr(primitive, "texcoord_indexset") and primitive.texcoord_indexset is not None and len(primitive.texcoord_indexset) > 0
                 else np.arange(len(uv_data), dtype=np.int32)
             )
 

--- a/urdf_usd_converter/_impl/material.py
+++ b/urdf_usd_converter/_impl/material.py
@@ -356,6 +356,10 @@ def store_dae_material_data(mesh_file_path: pathlib.Path, _collada: collada.Coll
         material_data = MaterialData()
         material_data.mesh_file_path = mesh_file_path
 
+        # Check if the material has a valid ID.
+        if not material.id:
+            raise ValueError("A material cannot be identified because it has no valid ID.")
+
         # If use_material_id is True, the material ID is used as the identification name.
         # If use_material_id is False, the material name is used as the identification name.
         # For the displayName of USD, use material.name when present.

--- a/urdf_usd_converter/_impl/material.py
+++ b/urdf_usd_converter/_impl/material.py
@@ -347,18 +347,18 @@ def store_dae_material_data(mesh_file_path: pathlib.Path, _collada: collada.Coll
         data: The conversion data.
     """
 
-    # Check for duplicate material names.
-    # If duplicate material names are found, the material ID will be used as the distinguishing identifier.
+    # Check for duplicate or missing material names.
+    # If names are duplicated or any material is unnamed, the material ID is used as the identifier.
     material_name_counts = Counter(material.name for material in _collada.materials)
-    use_material_id = any(count > 1 for count in material_name_counts.values())
+    use_material_id = any(count > 1 for count in material_name_counts.values()) or any(not material.name for material in _collada.materials)
 
     for material in _collada.materials:
         material_data = MaterialData()
         material_data.mesh_file_path = mesh_file_path
 
-        # If use_material_id is True, the "material name" is used as the material identification name.
-        # If use_material_id is False, the "material ID" is used as the material identification name.
-        # For the displayName of USD, use material.name.
+        # If use_material_id is True, the material ID is used as the identification name.
+        # If use_material_id is False, the material name is used as the identification name.
+        # For the displayName of USD, use material.name when present.
         material_data.name = material.id if use_material_id else material.name
         material_data.material_name = material.name
         material_data.use_material_id = use_material_id


### PR DESCRIPTION
Fixes #127 

## Description

If a material name is missing in a COLLADA file (.dae), the material ID is now used for identification.  
The issue was caused by the omission of the “material name does not exist” pattern in the material specifications for the urdf-usd-converter.  
Since the Material ID itself always exists as a unique name, in this case, we decided to use it as the material name in USD.  

We use the material ID as the material name under the following conditions.

- If there are duplicate names for materials within the material list in dae
- When there is a material without a name in the material list in dae

The material name is used for identification purposes when the following conditions are met.  

- When all materials in dae have unique material names and there are no duplicate names.

We have also added a feature that displays a warning message if a material ID does not exist in the dae file.  
In this case, the mesh will not be loaded.  

```
A material cannot be identified because it has no valid ID.
```

## Unit tests

### The material name does not exist

- dae: tests/data/assets/unnamed_material.dae
- urdf: tests/data/unnamed_mat.urdf
- unit test: - tests/testMaterial.py - test_dae_unnamed_material
 
### Normals and UVs are missing

- dae: tests/data/assets/no_normal.dae
- urdf: tests/data/dae_no_normal.urdf
- unit test: tests/testMeshDae.py - test_dae_no_normal

### If the material ID does not exist

- dae: tests/data/assets/no_material_id.dae
- urdf: tests/data/dae_no_material_id.urdf
- unit test: tests/testMeshDae.py - test_dae_no_material_id

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
