### PR TITLE
Fixed 'newton:inertia' body-frame transform for inertial 'origin.rpy'

### DIFF
--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -377,7 +377,7 @@ The origin of an inertial element is the position and orientation of the link’
 | URDF | OpenUSD | Description |
 | :---- | :---- | :---- |
 | [xyz](#property-xyz) | `physics:centerOfMass` | Position |
-| [rpy](#property-rpy) | `physics:principalAxes` (see also [inertia](#element-inertia)) | Orientation of the principal axes of inertia, represented as roll, pitch, yaw Euler rotations in radians |
+| [rpy](#property-rpy) | `physics:principalAxes`,<br>`newton:inertia` (see also [inertia](#element-inertia)) | Orientation of the inertial frame relative to the link, represented as roll, pitch, yaw Euler rotations in radians |
 
 ###### *Property: xyz*
 
@@ -385,9 +385,9 @@ The `origin.xyz` maps to `physics:centerOfMass` attribute of `UsdPhysicsMassAPI`
 
 ###### *Property: rpy*
 
-The `origin.rpy` of an inertial element is an additional rotation to the principal axes for the moment of inertia. They are stored in URDF as roll, pitch, yaw Euler rotations in radians.
+The `origin.rpy` of an inertial element is the orientation of the inertial frame (in which the URDF inertia tensor is expressed) relative to the link frame. They are stored in URDF as roll, pitch, yaw Euler rotations in radians.
 
-This concept is not directly representable in UsdPhysics as a separate attribute, so it must be baked into the `physics:principalAxes` attribute. See [inertia](#element-inertia) for details on obtaining the aligned `physics:principalAxes`. Once the aligned axes are obtained, the rpy should be used to rotate them as follows:
+This concept is not directly representable in UsdPhysics as a separate attribute, so it must be baked into both `physics:principalAxes` and `newton:inertia`. See [inertia](#element-inertia) for details. For `physics:principalAxes`, once the aligned axes are obtained from eigenvalue decomposition of the URDF inertia tensor, the rpy should be used to rotate them as follows:
 
 1. Convert rpy from Euler rotation radians to a Quaternion  
 2. `quatf orientedAxes = orientation * principalAxis  `
@@ -407,18 +407,24 @@ The inertia element contains 6 named properties, which can be used to construct 
 [ ixz  iyz  izz ]
 ```
 
-In USD, this maps to `physics:principalAxes` & `physics:diagonalInertia`, so must be computed via eigenvalue decomposition.
+In URDF, this tensor is expressed in the inertial frame defined by [`origin`](#element-origin). In USD, both of the following representations are authored on the link Prim:
 
-However, in Newton USD Schemas there is `NewtonMassAPI` which provides a `newton:inertia` attribute that exactly matches the layout of the URDF inertia element as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`. Both representations are authored: `physics:principalAxes` and `physics:diagonalInertia` for UsdPhysics consumers, and `newton:inertia` for the symmetric inertia tensor in URDF layout.
+- `physics:principalAxes` and `physics:diagonalInertia` — computed via eigenvalue decomposition of the URDF inertia tensor, then composing `origin.rpy` into `physics:principalAxes` as described above.
+- `newton:inertia` (`NewtonMassAPI`) — the full symmetric inertia tensor as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]` **in the body's local (link) frame**.
 
-| URDF | OpenUSD | Description |
+Because `newton:inertia` must be in the body frame, the URDF values must not be copied verbatim when `origin.rpy` is non-identity.  
+Rotate the URDF tensor into the link frame as `I_body = R * I_urdf * R^T`, then author `newton:inertia` from `I_body` as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`.  
+When `origin` is omitted or `rpy` is identity, `I_body = I_urdf` and the component mapping below matches the URDF attributes directly.  
+`origin.xyz` affects only `physics:centerOfMass`; it does not change the inertia tensor.
+
+| Body-frame component | OpenUSD | Description |
 | :---- | :---- | :---- |
-| ixx | `newton:inertia[0]` | moment of inertia about the x axis |
-| iyy | `newton:inertia[1]` | moment of inertia about the y axis |
-| izz | `newton:inertia[2]` | moment of inertia about the z axis |
-| ixy | `newton:inertia[3]` | product of inertia |
-| ixz | `newton:inertia[4]` | product of inertia |
-| iyz | `newton:inertia[5]` | product of inertia |
+| Ixx | `newton:inertia[0]` | moment of inertia about the x axis |
+| Iyy | `newton:inertia[1]` | moment of inertia about the y axis |
+| Izz | `newton:inertia[2]` | moment of inertia about the z axis |
+| Ixy | `newton:inertia[3]` | product of inertia |
+| Ixz | `newton:inertia[4]` | product of inertia |
+| Iyz | `newton:inertia[5]` | product of inertia |
 
 ### link/visual
 

--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -414,8 +414,11 @@ In URDF, this tensor is expressed in the inertial frame defined by [`origin`](#e
 
 Because `newton:inertia` must be in the body frame, the URDF values must not be copied verbatim when `origin.rpy` is non-identity.  
 Rotate the URDF tensor into the link frame as `I_body = R * I_urdf * R^T`, then author `newton:inertia` from `I_body` as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`.  
+`R` is built from `origin.rpy` using URDF's fixed-axis (extrinsic) XYZ convention, `R = Rz(yaw) * Ry(pitch) * Rx(roll)`, which is the assumption the whole transform rests on.  
 When `origin` is omitted or `rpy` is identity, `I_body = I_urdf` and the component mapping below matches the URDF attributes directly.  
 `origin.xyz` affects only `physics:centerOfMass`; it does not change the inertia tensor.
+
+`newton:inertia` is a `double[]`, so `R` should be built in double precision. Deriving it from a single-precision quaternion loses roughly 7 significant digits, which defeats the purpose of an attribute whose schema documentation states that *"Double precision prevents lossy conversion from source data that already represents the full tensor"*.
 
 | Body-frame component | OpenUSD | Description |
 | :---- | :---- | :---- |

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -178,5 +178,14 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(0.77679752, 2.1640169, 3.0591856), 1e-6))
         self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.0463736, 0.2748650, 0.9481796, 0.1524932))
-        self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1)
+        # `newton:inertia` is in the body/link frame (URDF inertia rotated by origin.rpy).
+        self._assert_newton_inertia(
+            link_box7_prim,
+            1.1744663749117963,
+            1.8959333480490628,
+            2.929600361158191,
+            0.592981060090011,
+            0.2047471774092129,
+            -0.38820849783010825,
+        )
         self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -11,12 +11,38 @@ from tests.util.ConverterTestCase import ConverterTestCase
 
 
 class TestPhysicsInertia(ConverterTestCase):
-    def _assert_newton_inertia(self, prim, ixx, iyy, izz, ixy, ixz, iyz):
+    def _rotation_from_rpy(self, rpy):
+        """
+        Build the rotation matrix for a URDF `origin.rpy`, which is a fixed-axis
+        (extrinsic) XYZ rotation: R = Rz(yaw) @ Ry(pitch) @ Rx(roll).
+        """
+        roll, pitch, yaw = rpy
+        cr, sr = math.cos(roll), math.sin(roll)
+        cp, sp = math.cos(pitch), math.sin(pitch)
+        cy, sy = math.cos(yaw), math.sin(yaw)
+        rotation_x = np.array([[1, 0, 0], [0, cr, -sr], [0, sr, cr]])
+        rotation_y = np.array([[cp, 0, sp], [0, 1, 0], [-sp, 0, cp]])
+        rotation_z = np.array([[cy, -sy, 0], [sy, cy, 0], [0, 0, 1]])
+        return rotation_z @ rotation_y @ rotation_x
+
+    def _assert_newton_inertia(self, prim, ixx, iyy, izz, ixy, ixz, iyz, rpy=(0.0, 0.0, 0.0)):
+        """
+        `newton:inertia` must be the URDF tensor expressed in the body/link frame,
+        so it is compared against `I_body = R(rpy) @ I_urdf @ R(rpy)^T` rebuilt here
+        from the URDF values. Deriving the expectation rather than hardcoding the
+        rotated components keeps a flipped transform direction reported as a
+        convention mismatch. The attribute is `double[]`, so the tolerance is tight
+        enough to catch a rotation built in single precision.
+        """
         self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        tensor = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]])
+        rotation = self._rotation_from_rpy(rpy)
+        i_body = rotation @ tensor @ rotation.T
+
         inertia = prim.GetAttribute("newton:inertia").Get()
-        expected = [ixx, iyy, izz, ixy, ixz, iyz]
+        expected = [i_body[0, 0], i_body[1, 1], i_body[2, 2], i_body[0, 1], i_body[0, 2], i_body[1, 2]]
         for actual, expected_value in zip(inertia, expected):
-            self.assertAlmostEqual(actual, expected_value, places=6)
+            self.assertAlmostEqual(actual, expected_value, places=12)
 
     def _assert_inertia_reconstructs(self, prim, ixx, iyy, izz, ixy, ixz, iyz, rpy=(0.0, 0.0, 0.0)):
         """
@@ -39,15 +65,7 @@ class TestPhysicsInertia(ConverterTestCase):
         reconstructed = rotation @ np.diag(mass_api.GetDiagonalInertiaAttr().Get()) @ rotation.T
 
         tensor = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]])
-        # URDF rpy is a fixed-axis (extrinsic) XYZ rotation: R = Rz(yaw) @ Ry(pitch) @ Rx(roll)
-        roll, pitch, yaw = rpy
-        cr, sr = math.cos(roll), math.sin(roll)
-        cp, sp = math.cos(pitch), math.sin(pitch)
-        cy, sy = math.cos(yaw), math.sin(yaw)
-        rotation_x = np.array([[1, 0, 0], [0, cr, -sr], [0, sr, cr]])
-        rotation_y = np.array([[cp, 0, sp], [0, 1, 0], [-sp, 0, cp]])
-        rotation_z = np.array([[cy, -sy, 0], [sy, cy, 0], [0, 0, 1]])
-        rotation_rpy = rotation_z @ rotation_y @ rotation_x
+        rotation_rpy = self._rotation_from_rpy(rpy)
         expected = rotation_rpy @ tensor @ rotation_rpy.T
 
         self.assertTrue(
@@ -179,13 +197,5 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(0.77679752, 2.1640169, 3.0591856), 1e-6))
         self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.0463736, 0.2748650, 0.9481796, 0.1524932))
         # `newton:inertia` is in the body/link frame (URDF inertia rotated by origin.rpy).
-        self._assert_newton_inertia(
-            link_box7_prim,
-            1.1744663749117963,
-            1.8959333480490628,
-            2.929600361158191,
-            0.592981060090011,
-            0.2047471774092129,
-            -0.38820849783010825,
-        )
+        self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
         self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -17,6 +17,7 @@ from .urdf_parser.elements import (
     ElementJoint,
     ElementLink,
     ElementMesh,
+    ElementPose,
     ElementVisual,
 )
 from .utils import (
@@ -114,6 +115,30 @@ def convert_link(parent: Usd.Prim, having_articulation_root: bool, link: Element
     return link_xform
 
 
+def _inertia_tensor_in_body_frame(inertia: ElementInertia, origin: ElementPose | None) -> list[float]:
+    """
+    Transform the URDF inertia tensor into the body's local frame.
+
+    URDF `inertia` is expressed in the inertial frame defined by `origin`.
+    `newton:inertia` requires the symmetric tensor in the body/link frame, so
+    when `origin.rpy` is non-identity the tensor is rotated as
+    `I_body = R^T * I_urdf * R` using `Gf`'s row-vector matrix convention
+    (`R = Gf.Matrix3d(quat)`).
+    """
+    ixx = inertia.get_with_default("ixx")
+    ixy = inertia.get_with_default("ixy")
+    ixz = inertia.get_with_default("ixz")
+    iyy = inertia.get_with_default("iyy")
+    iyz = inertia.get_with_default("iyz")
+    izz = inertia.get_with_default("izz")
+    # Gf.Matrix3d is row-major: (r0c0, r0c1, r0c2, r1c0, ...)
+    mat = Gf.Matrix3d(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)
+    if origin:
+        rotation = Gf.Matrix3d(float3_to_quatf(origin.get_with_default("rpy")))
+        mat = rotation.GetTranspose() * mat * rotation
+    return [mat[0, 0], mat[1, 1], mat[2, 2], mat[0, 1], mat[0, 2], mat[1, 2]]
+
+
 def apply_inertial(prim: Usd.Prim, link: ElementLink, data: ConversionData):
     """
     Set the inertial parameters of a link.
@@ -130,18 +155,10 @@ def apply_inertial(prim: Usd.Prim, link: ElementLink, data: ConversionData):
         orientation, diag_inertia = extract_inertia(inertia)
         mass_api.GetPrincipalAxesAttr().Set(orientation)
         mass_api.GetDiagonalInertiaAttr().Set(diag_inertia)
-        set_schema_attribute(
-            prim_over,
-            "newton:inertia",
-            [
-                inertia.get_with_default("ixx"),
-                inertia.get_with_default("iyy"),
-                inertia.get_with_default("izz"),
-                inertia.get_with_default("ixy"),
-                inertia.get_with_default("ixz"),
-                inertia.get_with_default("iyz"),
-            ],
-        )
+
+        # `newton:inertia` is in body local frame
+        i_body = _inertia_tensor_in_body_frame(inertia, link.inertial.origin)
+        set_schema_attribute(prim_over, "newton:inertia", i_body)
 
     if link.inertial.origin:
         position = Gf.Vec3f(link.inertial.origin.get_with_default("xyz"))

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -21,6 +21,7 @@ from .urdf_parser.elements import (
     ElementVisual,
 )
 from .utils import (
+    float3_to_quatd,
     float3_to_quatf,
     get_geometry_name,
     set_schema_attribute,
@@ -122,8 +123,12 @@ def _inertia_tensor_in_body_frame(inertia: ElementInertia, origin: ElementPose |
     URDF `inertia` is expressed in the inertial frame defined by `origin`.
     `newton:inertia` requires the symmetric tensor in the body/link frame, so
     when `origin.rpy` is non-identity the tensor is rotated as
-    `I_body = R^T * I_urdf * R` using `Gf`'s row-vector matrix convention
-    (`R = Gf.Matrix3d(quat)`).
+    `I_body = R * I_urdf * R^T`, where `R` is built from URDF's fixed-axis
+    (extrinsic) XYZ convention, `R = Rz(yaw) * Ry(pitch) * Rx(roll)`.
+
+    In `Gf`'s row-vector convention `Gf.Matrix3d(quat)` is the transpose of the
+    column-convention `R`, so the `R_gf.GetTranspose() * I * R_gf` below
+    evaluates to the standard `R * I * R^T`.
     """
     ixx = inertia.get_with_default("ixx")
     ixy = inertia.get_with_default("ixy")
@@ -134,7 +139,7 @@ def _inertia_tensor_in_body_frame(inertia: ElementInertia, origin: ElementPose |
     # Gf.Matrix3d is row-major: (r0c0, r0c1, r0c2, r1c0, ...)
     mat = Gf.Matrix3d(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)
     if origin:
-        rotation = Gf.Matrix3d(float3_to_quatf(origin.get_with_default("rpy")))
+        rotation = Gf.Matrix3d(float3_to_quatd(origin.get_with_default("rpy")))
         mat = rotation.GetTranspose() * mat * rotation
     return [mat[0, 0], mat[1, 1], mat[2, 2], mat[0, 1], mat[0, 2], mat[1, 2]]
 

--- a/urdf_usd_converter/_impl/utils.py
+++ b/urdf_usd_converter/_impl/utils.py
@@ -35,12 +35,7 @@ def float3_to_quatf(rpy: tuple[float, float, float]) -> Gf.Quatf:
     The roll, pitch, yaw angles are in radians.
     USD converts this to degrees.
     """
-    rotation = (
-        Gf.Rotation(Gf.Vec3d(1, 0, 0), math.degrees(rpy[0]))
-        * Gf.Rotation(Gf.Vec3d(0, 1, 0), math.degrees(rpy[1]))
-        * Gf.Rotation(Gf.Vec3d(0, 0, 1), math.degrees(rpy[2]))
-    )
-    return Gf.Quatf(rotation.GetQuat())
+    return Gf.Quatf(float3_to_quatd(rpy))
 
 
 def float3_to_quatd(rpy: tuple[float, float, float]) -> Gf.Quatd:

--- a/urdf_usd_converter/_impl/utils.py
+++ b/urdf_usd_converter/_impl/utils.py
@@ -16,6 +16,7 @@ from .urdf_parser.elements import (
 )
 
 __all__ = [
+    "float3_to_quatd",
     "float3_to_quatf",
     "get_authoring_metadata",
     "get_geometry_name",
@@ -40,6 +41,20 @@ def float3_to_quatf(rpy: tuple[float, float, float]) -> Gf.Quatf:
         * Gf.Rotation(Gf.Vec3d(0, 0, 1), math.degrees(rpy[2]))
     )
     return Gf.Quatf(rotation.GetQuat())
+
+
+def float3_to_quatd(rpy: tuple[float, float, float]) -> Gf.Quatd:
+    """
+    Convert a tuple of roll, pitch, yaw angles to a Gf.Quatd.
+    The roll, pitch, yaw angles are in radians.
+    USD converts this to degrees.
+    """
+    rotation = (
+        Gf.Rotation(Gf.Vec3d(1, 0, 0), math.degrees(rpy[0]))
+        * Gf.Rotation(Gf.Vec3d(0, 1, 0), math.degrees(rpy[1]))
+        * Gf.Rotation(Gf.Vec3d(0, 0, 1), math.degrees(rpy[2]))
+    )
+    return Gf.Quatd(rotation.GetQuat())
 
 
 def get_geometry_name(element: ElementVisual | ElementCollision) -> str:


### PR DESCRIPTION
Fixes #131 

## Description

- Fix authoring of `newton:inertia` so the URDF inertia tensor is transformed into the body/link local frame when `inertial/origin.rpy` is set (previously the URDF values were copied verbatim).
- URDF `<inertia>` is expressed in the inertial frame defined by `<origin>`; `newton:inertia` must be in the body's local frame, so apply `I_body = R * I_urdf * R^T` using `origin.rpy`.
- Updated concept mapping docs.

## Unit test

- tests/testPhysicsInertia.py - TestPhysicsInertia - test_physics_inertia

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
