### PR TITLE
Author newton:mimicCoef0 in degrees for angular followers

### DIFF
--- a/tests/data/mimic_joint.urdf
+++ b/tests/data/mimic_joint.urdf
@@ -35,6 +35,24 @@
         </visual>
     </link>
 
+    <link name="linkC">
+        <visual>
+            <origin rpy="0 0 0" xyz="0.27 0 0"/>
+            <geometry>
+                <box size="0.5 0.2 0.2"/>
+            </geometry>
+        </visual>
+    </link>
+
+    <link name="linkD">
+        <visual>
+            <origin rpy="0 0 0" xyz="0.27 0 0"/>
+            <geometry>
+                <box size="0.5 0.2 0.2"/>
+            </geometry>
+        </visual>
+    </link>
+
     <joint name="joint_base" type="fixed">
         <origin rpy="0 0 0" xyz="0 0.4 0"/>
         <parent link="BaseLinkA"/>
@@ -53,7 +71,22 @@
         <child link="linkB"/>
         <axis xyz="0 1 0"/>
         <limit lower="-0.7" upper="0.5"/>
-        <mimic joint="jointA" multiplier="2.0" offset="0.0"/>
+        <mimic joint="jointA" multiplier="2.0" offset="0.5"/>
+    </joint>
+    <joint name="jointC" type="prismatic">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <parent link="linkA"/>
+        <child link="linkC"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-0.7" upper="0.5"/>
+    </joint>
+    <joint name="jointD" type="prismatic">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <parent link="linkB"/>
+        <child link="linkD"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-0.7" upper="0.5"/>
+        <mimic joint="jointC" multiplier="2.0" offset="0.25"/>
     </joint>
 </robot>
 

--- a/tests/testJoints.py
+++ b/tests/testJoints.py
@@ -599,12 +599,16 @@ class TestJoints(ConverterTestCase):
 
         self.assertTrue(joint_b_prim.HasAPI("NewtonMimicAPI"))
 
-        # 'newton:mimicEnabled', 'newton:mimicCoef0' return False because they have default values.
+        # 'newton:mimicEnabled' returns False because it has a default value.
         self.assertFalse(joint_b_prim.GetAttribute("newton:mimicEnabled").HasAuthoredValue())
-        self.assertFalse(joint_b_prim.GetAttribute("newton:mimicCoef0").HasAuthoredValue())
 
+        self.assertTrue(joint_b_prim.GetAttribute("newton:mimicCoef0").HasAuthoredValue())
         self.assertTrue(joint_b_prim.GetAttribute("newton:mimicCoef1").HasAuthoredValue())
         self.assertTrue(joint_b_prim.GetAttribute("newton:mimicEnabled").Get())
+        # URDF authors the offset in the follower's position units -- radians for a
+        # revolute joint -- while NewtonMimicAPI documents coef0 in degrees.
+        self.assertAlmostEqual(joint_b_prim.GetAttribute("newton:mimicCoef0").Get(), math.degrees(0.5), places=4)
+        # The multiplier is dimensionless and is authored unscaled.
         self.assertAlmostEqual(joint_b_prim.GetAttribute("newton:mimicCoef1").Get(), 2.0)
 
         self.assertTrue(joint_b_prim.HasRelationship("newton:mimicJoint"))
@@ -612,3 +616,11 @@ class TestJoints(ConverterTestCase):
         self.assertEqual(len(rel.GetTargets()), 1)
         ref_joint = rel.GetTargets()[0]
         self.assertEqual(ref_joint, "/mimic_joint/Physics/jointA")
+
+        # A prismatic follower carries distance units, so the offset is not converted.
+        joint_d_prim = physics_scope_prim.GetChild("jointD")
+        self.assertTrue(joint_d_prim.IsValid())
+        self.assertTrue(joint_d_prim.IsA(UsdPhysics.PrismaticJoint))
+        self.assertTrue(joint_d_prim.HasAPI("NewtonMimicAPI"))
+        self.assertAlmostEqual(joint_d_prim.GetAttribute("newton:mimicCoef0").Get(), 0.25, places=6)
+        self.assertAlmostEqual(joint_d_prim.GetAttribute("newton:mimicCoef1").Get(), 2.0)

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -425,6 +425,20 @@ def _convert_joint_velocity_limit(joint_type: str, velocity: float) -> float:
     return velocity
 
 
+def _convert_mimic_offset(joint_type: str, offset: float) -> float:
+    """
+    Convert a URDF mimic offset to NewtonMimicAPI units.
+
+    URDF authors ``<mimic offset>`` in the follower joint's position units, so revolute
+    and continuous joints use radians while NewtonMimicAPI documents ``newton:mimicCoef0``
+    in degrees. Prismatic joints use distance in both and need no conversion. The
+    multiplier is dimensionless.
+    """
+    if joint_type in ("revolute", "continuous"):
+        return math.degrees(offset)
+    return offset
+
+
 def apply_newton_joint_api(element_joint: ElementJoint, prim: Usd.Prim):
     """
     Map URDF joint dynamics and velocity limits to NewtonJointAPI.
@@ -514,7 +528,7 @@ def set_physics_mimic_joint(element_joint: ElementJoint, prim: Usd.Prim, ref_pri
     # Newton USD Schemas: joint0 = coef1 * joint1 + coef0
     prim.ApplyAPI("NewtonMimicAPI")
     set_schema_attribute(prim, "newton:mimicEnabled", True)
-    set_schema_attribute(prim, "newton:mimicCoef0", offset)
+    set_schema_attribute(prim, "newton:mimicCoef0", _convert_mimic_offset(element_joint.type, offset))
     set_schema_attribute(prim, "newton:mimicCoef1", multiplier)
 
     rel = prim.CreateRelationship("newton:mimicJoint")


### PR DESCRIPTION
## Description

Author `newton:mimicCoef0` in degrees for `revolute` and `continuous` follower joints.

URDF authors `<mimic offset>` in the follower joint's position units, which is radians for angular joints. `NewtonMimicAPI` documents `newton:mimicCoef0` as "distance or degrees (matches the joint type)", so angular followers were authored a factor of `180/pi` too small. Prismatic followers are already in distance units and are unaffected, as is the dimensionless `newton:mimicCoef1`.

Fixes #133.

### Why the existing test did not catch it

`tests/data/mimic_joint.urdf` used `offset="0.0"`. Because `set_schema_attribute()` skips values matching the schema default, the test could only assert that `newton:mimicCoef0` was *unauthored* — a zero offset cannot distinguish a missing conversion from a correct one.

The fixture now gives `jointB` a non-zero angular offset, and adds a prismatic mimic pair (`jointC`/`jointD`) so the pass-through case is pinned too. Reverting the conversion fails the test with `0.5 != 28.64788975654116`.

### Sequencing

Newton's USD importer has the same missing conversion, so the two currently agree with each other and disagree with the schema. **Landing this alone makes URDF → USD → Newton round trips wrong by `180/pi`.** The Newton-side fix is prepared and should land first or together with this. See newton-physics/mujoco-usd-converter#107 for the cross-repo picture, and newton-physics/newton-usd-schemas#80 which documents the related same-joint-type requirement.

Assets produced by earlier versions hold radian values in a degrees field and need reconverting rather than re-blessing.

No changelog entry, per the release-prep workflow.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).

## Test plan

```
uv run python -m unittest discover -s ./tests   # 130 tests
```

Verified `test_mimic_joints` fails without the conversion and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
