### PR TITLE
Fixed joint body0 retargeting for ghost links with articulated children

### DIFF
--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -282,11 +282,10 @@ This is evaluated independently for each link.
 A Ghost Link on a Fixed joint still has its rigid body removed even when a descendant branch continues to a non-Ghost, articulated link—for example, a run of Ghost Links on Fixed joints followed by a Revolute joint to a link with collision geometry.  
 
 Physics joints whose child link has no rigid body are not authored in the Physics scope.  
-In USD `PhysicsJoint`, `body1` must reference a prim that has a rigid body; joints that would place a rigid-body-less child on `body1` are omitted.  
+In USD `PhysicsJoint`, `body0` may reference a prim without a rigid body, but `body1` must reference a prim that has one; joints that would place a rigid-body-less child on `body1` are omitted.  
 Fixed joints that only connect Ghost Links without rigid bodies are therefore dropped, while joints whose child still has a rigid body (for example, a Revolute joint to the first non-Ghost descendant) remain.
 
-An articulation is built from the `body0`/`body1` relationships of its joints, not from the USD hierarchy, so a joint whose `body0` targets a Ghost Link would detach its child from the rest of the articulation.  
-When the parent link of a joint has no rigid body, `body0` therefore targets the closest ancestor link that does have one, or the default prim (the world) when no such ancestor exists.  
+When the parent link of a joint has no rigid body, this converter authors `body0` as the closest ancestor link that does have one (or the default prim / world when none exists), rather than relying on consumers to walk ancestors from a ghost-link target themselves.  
 Because the joint frame is expressed relative to `body1`, the `origin` of the Fixed joints that were dropped along the way is accumulated into `physics:localPos0` and `physics:localRot0`, which keeps the child in the same place.
 
 The nested Geometry Xform hierarchy is not removed; only rigid-body assignment and redundant physics joints change.  

--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -282,8 +282,12 @@ This is evaluated independently for each link.
 A Ghost Link on a Fixed joint still has its rigid body removed even when a descendant branch continues to a non-Ghost, articulated link—for example, a run of Ghost Links on Fixed joints followed by a Revolute joint to a link with collision geometry.  
 
 Physics joints whose child link has no rigid body are not authored in the Physics scope.  
-In USD `PhysicsJoint`, `body0` may reference a prim without a rigid body, but `body1` must reference a prim that has one; joints that would place a rigid-body-less child on `body1` are omitted.  
+In USD `PhysicsJoint`, `body1` must reference a prim that has a rigid body; joints that would place a rigid-body-less child on `body1` are omitted.  
 Fixed joints that only connect Ghost Links without rigid bodies are therefore dropped, while joints whose child still has a rigid body (for example, a Revolute joint to the first non-Ghost descendant) remain.
+
+An articulation is built from the `body0`/`body1` relationships of its joints, not from the USD hierarchy, so a joint whose `body0` targets a Ghost Link would detach its child from the rest of the articulation.  
+When the parent link of a joint has no rigid body, `body0` therefore targets the closest ancestor link that does have one, or the default prim (the world) when no such ancestor exists.  
+Because the joint frame is expressed relative to `body1`, the `origin` of the Fixed joints that were dropped along the way is accumulated into `physics:localPos0` and `physics:localRot0`, which keeps the child in the same place.
 
 The nested Geometry Xform hierarchy is not removed; only rigid-body assignment and redundant physics joints change.  
 
@@ -352,7 +356,8 @@ The USD content can then be simplified to:
 In Physics, only the joint with `parent=BaseLink` and `child=BoxLink` remains (in addition to any world/root joint policy used elsewhere in this converter).
 
 When Ghost Links on Fixed joints appear **before** an articulated, non-Ghost descendant, the same per-link rule applies.  
-For example, with `BaseLink → ghost_link → ghost_link_2 → ghost_link_3 → link_box` (three Fixed joints, then a Revolute joint to `link_box`), rigid bodies are omitted on `ghost_link`, `ghost_link_2`, and `ghost_link_3`, the three internal Fixed joints are not authored, and only `joint_box` (Revolute, parent `ghost_link_3`, child `link_box`) remains among the joints along that chain.  
+For example, with `BaseLink → ghost_link → ghost_link_2 → ghost_link_3 → link_box` (three Fixed joints, then a Revolute joint to `link_box`), rigid bodies are omitted on `ghost_link`, `ghost_link_2`, and `ghost_link_3`, and the three internal Fixed joints are not authored.  
+Only `joint_box` remains among the joints along that chain, and its `body0` targets `BaseLink` rather than `ghost_link_3`, with the origins of the three dropped Fixed joints accumulated into its `physics:localPos0`.  
 
 ### link/inertial
 

--- a/tests/data/link_ghost_link_children.urdf
+++ b/tests/data/link_ghost_link_children.urdf
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<robot name="link_ghost_link_children">
+  <!-- A `Ghost Link` sits between "BaseLink" and "box_link", and is the parent of a revolute joint. -->
+  <!-- The revolute joint targets "BaseLink" on body0, because the ghost link has no rigid body. -->
+  <link name="BaseLink">
+    <visual>
+      <geometry>
+        <box size="0.5 0.5 0.5"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.5 0.5 0.5"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="ghost_link" />
+  <link name="box_link">
+    <visual>
+      <origin rpy="0 0 0" xyz="0.55 0 0"/>
+      <geometry>
+        <box size="1.0 0.2 0.2"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.55 0 0"/>
+      <geometry>
+        <box size="1.0 0.2 0.2"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="joint1" type="fixed">
+    <origin rpy="0 0 0" xyz="0.3 0 0"/>
+    <parent link="BaseLink"/>
+    <child link="ghost_link"/>
+  </joint>
+  <joint name="joint2" type="revolute">
+    <origin rpy="0 0 0" xyz="0.1 0 0"/>
+    <parent link="ghost_link"/>
+    <child link="box_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.6" upper="0.6"/>
+  </joint>
+</robot>

--- a/tests/testGhostLink.py
+++ b/tests/testGhostLink.py
@@ -262,15 +262,24 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(joint_box_prim.IsValid())
         self.assertTrue(joint_box_prim.IsA(UsdPhysics.RevoluteJoint))
         joint = UsdPhysics.RevoluteJoint(joint_box_prim)
-        # body0 is retargeted from "ghost_link_3" to "BaseLink", the closest ancestor with a rigid body.
+        # body0 is authored as "BaseLink" (resolved from "ghost_link_3") so consumers
+        # reading body0 directly see the rigid-body ancestor without walking the hierarchy.
         self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain/Geometry/BaseLink"])
         self.assertEqual(
             joint.GetBody1Rel().GetTargets(), ["/link_skip_ghost_link_chain/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3/link_box"]
         )
+        # Authored localPos0 is relative to BaseLink (0.1+0.2+0.2), matching the world-space joint.
         self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
         self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
         self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))
+
+        # Resolved parse agrees with the authored retargeting (same body0 / localPose0).
+        parsed = UsdPhysics.LoadUsdPhysicsFromRange(stage, ["/"])
+        revolute_paths, revolute_descs = parsed[UsdPhysics.ObjectType.RevoluteJoint]
+        self.assertEqual(list(revolute_paths), [joint_box_prim.GetPath()])
+        self.assertEqual(str(revolute_descs[0].body0), "/link_skip_ghost_link_chain/Geometry/BaseLink")
+        self.assertTrue(Gf.IsClose(revolute_descs[0].localPose0Position, Gf.Vec3f(0, 0, 0.5), 1e-6))
 
     def test_link_skip_ghost_link_chain_end(self):
         input_path = "tests/data/link_skip_ghost_link_chain_end.urdf"
@@ -433,7 +442,8 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(joint_box_prim.IsValid())
         self.assertTrue(joint_box_prim.IsA(UsdPhysics.RevoluteJoint))
         joint = UsdPhysics.RevoluteJoint(joint_box_prim)
-        # body0 is retargeted from "ghost_link_3" to "BaseLink", the closest ancestor with a rigid body.
+        # body0 is authored as "BaseLink" (resolved from "ghost_link_3") so consumers
+        # reading body0 directly see the rigid-body ancestor without walking the hierarchy.
         self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain_branch/Geometry/BaseLink"])
         self.assertEqual(
             joint.GetBody1Rel().GetTargets(), ["/link_skip_ghost_link_chain_branch/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3/link_box"]
@@ -692,8 +702,8 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(joint2_prim.IsValid())
         self.assertTrue(joint2_prim.IsA(UsdPhysics.RevoluteJoint))
         joint = UsdPhysics.RevoluteJoint(joint2_prim)
-        # body0 is retargeted from "ghost_link" to "BaseLink", the closest ancestor with a rigid body,
-        # so that "box_link" stays connected to the articulation.
+        # body0 is authored as "BaseLink" (resolved from "ghost_link") so consumers
+        # reading body0 directly see the rigid-body ancestor without walking the hierarchy.
         self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_ghost_link_children/Geometry/BaseLink"])
         self.assertEqual(joint.GetBody1Rel().GetTargets(), ["/link_ghost_link_children/Geometry/BaseLink/ghost_link/box_link"])
         # The origin of "joint1" and "joint2" are accumulated into the joint frame of "BaseLink".
@@ -701,3 +711,10 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
         self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
         self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))
+
+        # Resolved parse agrees with the authored retargeting (same body0 / localPose0).
+        parsed = UsdPhysics.LoadUsdPhysicsFromRange(stage, ["/"])
+        revolute_paths, revolute_descs = parsed[UsdPhysics.ObjectType.RevoluteJoint]
+        self.assertEqual(list(revolute_paths), [joint2_prim.GetPath()])
+        self.assertEqual(str(revolute_descs[0].body0), "/link_ghost_link_children/Geometry/BaseLink")
+        self.assertTrue(Gf.IsClose(revolute_descs[0].localPose0Position, Gf.Vec3f(0.4, 0, 0), 1e-6))

--- a/tests/testGhostLink.py
+++ b/tests/testGhostLink.py
@@ -262,11 +262,12 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(joint_box_prim.IsValid())
         self.assertTrue(joint_box_prim.IsA(UsdPhysics.RevoluteJoint))
         joint = UsdPhysics.RevoluteJoint(joint_box_prim)
-        self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3"])
+        # body0 is retargeted from "ghost_link_3" to "BaseLink", the closest ancestor with a rigid body.
+        self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain/Geometry/BaseLink"])
         self.assertEqual(
             joint.GetBody1Rel().GetTargets(), ["/link_skip_ghost_link_chain/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3/link_box"]
         )
-        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0.2), 1e-6))
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
         self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
         self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))
@@ -432,13 +433,12 @@ class TestGhostLink(ConverterTestCase):
         self.assertTrue(joint_box_prim.IsValid())
         self.assertTrue(joint_box_prim.IsA(UsdPhysics.RevoluteJoint))
         joint = UsdPhysics.RevoluteJoint(joint_box_prim)
-        self.assertEqual(
-            joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain_branch/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3"]
-        )
+        # body0 is retargeted from "ghost_link_3" to "BaseLink", the closest ancestor with a rigid body.
+        self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_skip_ghost_link_chain_branch/Geometry/BaseLink"])
         self.assertEqual(
             joint.GetBody1Rel().GetTargets(), ["/link_skip_ghost_link_chain_branch/Geometry/BaseLink/ghost_link/ghost_link_2/ghost_link_3/link_box"]
         )
-        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0.2), 1e-6))
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
         self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
         self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))
@@ -627,3 +627,77 @@ class TestGhostLink(ConverterTestCase):
 
         joint_no_inertia_prim = physics_scope_prim.GetChild("joint_no_inertia")
         self.assertFalse(joint_no_inertia_prim.IsValid())
+
+    def test_link_ghost_link_children(self):
+        input_path = "tests/data/link_ghost_link_children.urdf"
+        output_dir = self.tmpDir()
+
+        converter = urdf_usd_converter.Converter()
+        asset_path = converter.convert(input_path, output_dir)
+        self.assertIsNotNone(asset_path)
+        self.assertTrue(pathlib.Path(asset_path.path).exists())
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+
+        default_prim = stage.GetDefaultPrim()
+        self.assertTrue(default_prim.IsValid())
+
+        geometry_scope_prim = default_prim.GetChild("Geometry")
+        self.assertTrue(geometry_scope_prim.IsValid())
+
+        # Check physics rigid bodies. This is a root link, and Articulation has been assigned to it.
+        base_link_prim = geometry_scope_prim.GetChild("BaseLink")
+        self.assertTrue(base_link_prim.IsValid())
+        self.assertTrue(base_link_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertTrue(base_link_prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+        self.assertTrue(base_link_prim.HasAPI("NewtonArticulationRootAPI"))
+
+        # This ghost link does not have a rigid body.
+        ghost_link_prim = base_link_prim.GetChild("ghost_link")
+        self.assertTrue(ghost_link_prim.IsValid())
+        self.assertFalse(ghost_link_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(ghost_link_prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+        self.assertFalse(ghost_link_prim.HasAPI("NewtonArticulationRootAPI"))
+
+        # This link has a rigid body.
+        box_link_prim = ghost_link_prim.GetChild("box_link")
+        self.assertTrue(box_link_prim.IsValid())
+        self.assertTrue(box_link_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(box_link_prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+        self.assertFalse(box_link_prim.HasAPI("NewtonArticulationRootAPI"))
+
+        # Check physics joint.
+        # "root_joint" and "joint2" are created.
+        # "joint1" is not created because it is a fixed joint and body1 is a ghost link without a rigid body.
+        physics_scope_prim = default_prim.GetChild("Physics")
+        self.assertTrue(physics_scope_prim.IsValid())
+        self.assertEqual(len(physics_scope_prim.GetChildren()), 2)
+
+        root_joint_prim = physics_scope_prim.GetChild("root_joint")
+        self.assertTrue(root_joint_prim.IsValid())
+        self.assertTrue(root_joint_prim.IsA(UsdPhysics.FixedJoint))
+        joint = UsdPhysics.FixedJoint(root_joint_prim)
+        self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_ghost_link_children"])
+        self.assertEqual(joint.GetBody1Rel().GetTargets(), ["/link_ghost_link_children/Geometry/BaseLink"])
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
+        self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
+        self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))
+
+        joint1_prim = physics_scope_prim.GetChild("joint1")
+        self.assertFalse(joint1_prim.IsValid())
+
+        joint2_prim = physics_scope_prim.GetChild("joint2")
+        self.assertTrue(joint2_prim.IsValid())
+        self.assertTrue(joint2_prim.IsA(UsdPhysics.RevoluteJoint))
+        joint = UsdPhysics.RevoluteJoint(joint2_prim)
+        # body0 is retargeted from "ghost_link" to "BaseLink", the closest ancestor with a rigid body,
+        # so that "box_link" stays connected to the articulation.
+        self.assertEqual(joint.GetBody0Rel().GetTargets(), ["/link_ghost_link_children/Geometry/BaseLink"])
+        self.assertEqual(joint.GetBody1Rel().GetTargets(), ["/link_ghost_link_children/Geometry/BaseLink/ghost_link/box_link"])
+        # The origin of "joint1" and "joint2" are accumulated into the joint frame of "BaseLink".
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos0Attr().Get(), Gf.Vec3f(0.4, 0, 0), 1e-6))
+        self.assertTrue(Gf.IsClose(joint.GetLocalPos1Attr().Get(), Gf.Vec3f(0, 0, 0), 1e-6))
+        self.assertRotationsAlmostEqual(joint.GetLocalRot0Attr().Get(), Gf.Quatf(1, 0, 0, 0))
+        self.assertRotationsAlmostEqual(joint.GetLocalRot1Attr().Get(), Gf.Quatf(1, 0, 0, 0))

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -311,7 +311,7 @@ def _has_rigid_body(link_name: str, data: ConversionData) -> bool:
     """
     link_prim = data.references[Tokens.Physics][link_name]
     prim = data.content[Tokens.Physics].GetPrimAtPath(link_prim.GetPath())
-    return prim and prim.HasAPI(UsdPhysics.RigidBodyAPI)
+    return bool(prim and prim.HasAPI(UsdPhysics.RigidBodyAPI))
 
 
 def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | None:
@@ -320,10 +320,6 @@ def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | Non
 
     Returns None when no ancestor owns one, which means the joint should target the world.
     """
-    # The kinematic root has no parent, so there is no rigid-body ancestor to find.
-    if link_name == data.link_hierarchy.root_link.name:
-        return None
-
     parent_link = data.link_hierarchy.get_link_parent(link_name)
     while parent_link is not None:
         if _has_rigid_body(parent_link.name, data):

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -310,8 +310,8 @@ def _has_rigid_body(link_name: str, data: ConversionData) -> bool:
     Check whether PhysicsRigidBodyAPI is applied to the prim of a link.
     """
     link_prim = data.references[Tokens.Physics][link_name]
-    prim_over = data.content[Tokens.Physics].OverridePrim(link_prim.GetPath())
-    return prim_over.HasAPI(UsdPhysics.RigidBodyAPI)
+    prim = data.content[Tokens.Physics].GetPrimAtPath(link_prim.GetPath())
+    return prim and prim.HasAPI(UsdPhysics.RigidBodyAPI)
 
 
 def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | None:
@@ -320,6 +320,11 @@ def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | Non
 
     Returns None when no ancestor owns one, which means the joint should target the world.
     """
+    root_name = data.link_hierarchy.get_root_link().name
+    # The kinematic root has no parent, so there is no rigid-body ancestor to find.
+    if link_name == root_name:
+        return None
+
     parent_link = data.link_hierarchy.get_link_parent(link_name)
     while parent_link is not None:
         if _has_rigid_body(parent_link.name, data):
@@ -346,8 +351,8 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
     #
     # If the joint is fixed, and body1 is a Ghost Link without a rigid body, creation of this joint is skipped.
     #
-    # If body0 is a Ghost Link without a rigid body, the joint targets the closest ancestor link that
-    # owns one, so that body1 stays connected to the articulation.
+    # If body0 is a Ghost Link without a rigid body, author body0 as the closest ancestor that owns
+    # one (or the world), so consumers that read body0 directly do not need to walk ancestors.
 
     # If the first link does not have a ghost link, create a fixed joint connecting the first link to the world.
     if not has_root_ghost_link:
@@ -379,8 +384,8 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
         if not _has_rigid_body(body1_link_name, data):
             continue
 
-        # A ghost link has no rigid body, so a joint targeting one on body0 would detach body1 from
-        # the articulation. Retarget body0 to the closest ancestor link that owns a rigid body.
+        # Author body0 as the closest rigid-body ancestor (or the world) rather than a ghost link,
+        # so the authored relationship matches what UsdPhysics would resolve by walking ancestors.
         if not _has_rigid_body(body0_link_name, data):
             body0_link_name = _find_rigid_body_ancestor(body0_link_name, data)
 

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -33,7 +33,7 @@ __all__ = ["convert_links"]
 
 def convert_links(data: ConversionData):
     geo_scope = data.content[Tokens.Geometry].GetDefaultPrim().GetChild(Tokens.Geometry).GetPrim()
-    root_link = data.link_hierarchy.get_root_link()
+    root_link = data.link_hierarchy.root_link
 
     # Creating a Link Hierarchy.
     convert_link(parent=geo_scope, having_articulation_root=False, link=root_link, data=data)
@@ -59,7 +59,7 @@ def convert_link(parent: Usd.Prim, having_articulation_root: bool, link: Element
     joints = data.link_hierarchy.get_link_joints(link.name)
 
     # Determines if the link is the root link.
-    is_root_link = link == data.link_hierarchy.get_root_link()
+    is_root_link = link.name == data.link_hierarchy.root_link.name
 
     # Determines if the root link is a ghost link (no inertia/colliders/visuals).
     has_ghost_link = data.link_hierarchy.has_ghost_link(link.name)
@@ -320,9 +320,8 @@ def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | Non
 
     Returns None when no ancestor owns one, which means the joint should target the world.
     """
-    root_name = data.link_hierarchy.get_root_link().name
     # The kinematic root has no parent, so there is no rigid-body ancestor to find.
-    if link_name == root_name:
+    if link_name == data.link_hierarchy.root_link.name:
         return None
 
     parent_link = data.link_hierarchy.get_link_parent(link_name)
@@ -338,8 +337,8 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
     Create physics joints.
     """
     # Determines if the root link is a ghost link (no inertia/colliders/visuals).
-    root_link = data.link_hierarchy.get_root_link()
-    has_root_ghost_link = data.link_hierarchy.has_ghost_link(root_link.name)
+    root_link_name = data.link_hierarchy.root_link.name
+    has_root_ghost_link = data.link_hierarchy.has_ghost_link(root_link_name)
 
     default_prim = parent.GetStage().GetDefaultPrim()
 
@@ -359,7 +358,7 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
         joint_name = "root_joint"
         joint_safe_name = data.name_cache.getPrimName(parent, joint_name)
         body0 = default_prim
-        body1 = data.references[Tokens.Physics][root_link.name]
+        body1 = data.references[Tokens.Physics][root_link_name]
         joint_frame = usdex.core.JointFrame(usdex.core.JointFrame.Space.Body1, Gf.Vec3d(0), Gf.Quatd.GetIdentity())
         physics_joint = usdex.core.definePhysicsFixedJoint(parent, joint_safe_name, body0, body1, joint_frame)
         if physics_joint and joint_name != joint_safe_name:

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -305,6 +305,29 @@ def extract_inertia(inertia: ElementInertia) -> tuple[Gf.Quatf, Gf.Vec3f]:
     return orientation, diag_inertia
 
 
+def _has_rigid_body(link_name: str, data: ConversionData) -> bool:
+    """
+    Check whether PhysicsRigidBodyAPI is applied to the prim of a link.
+    """
+    link_prim = data.references[Tokens.Physics][link_name]
+    prim_over = data.content[Tokens.Physics].OverridePrim(link_prim.GetPath())
+    return prim_over.HasAPI(UsdPhysics.RigidBodyAPI)
+
+
+def _find_rigid_body_ancestor(link_name: str, data: ConversionData) -> str | None:
+    """
+    Find the closest ancestor of a link that owns a rigid body.
+
+    Returns None when no ancestor owns one, which means the joint should target the world.
+    """
+    parent_link = data.link_hierarchy.get_link_parent(link_name)
+    while parent_link is not None:
+        if _has_rigid_body(parent_link.name, data):
+            return parent_link.name
+        parent_link = data.link_hierarchy.get_link_parent(parent_link.name)
+    return None
+
+
 def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
     """
     Create physics joints.
@@ -322,6 +345,9 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
     # we do not assign a rigid body to that link when building the prim hierarchy.
     #
     # If the joint is fixed, and body1 is a Ghost Link without a rigid body, creation of this joint is skipped.
+    #
+    # If body0 is a Ghost Link without a rigid body, the joint targets the closest ancestor link that
+    # owns one, so that body1 stays connected to the articulation.
 
     # If the first link does not have a ghost link, create a fixed joint connecting the first link to the world.
     if not has_root_ghost_link:
@@ -348,18 +374,18 @@ def physics_joints(parent: Usd.Prim, link: ElementLink, data: ConversionData):
         body0_link_name = joint.parent.get_with_default("link")
         body1_link_name = joint.child.get_with_default("link")
 
-        has_ghost_link = has_root_ghost_link and root_link.name == body0_link_name
-        body0 = data.references[Tokens.Physics][body0_link_name] if not has_ghost_link else default_prim
-        body1 = data.references[Tokens.Physics][body1_link_name]
-
-        # Check whether PhysicsRigidBodyAPI is applied to body1.
-        body1_prim_over = data.content[Tokens.Physics].OverridePrim(body1.GetPath())
-        body1_has_rigid_body = body1_prim_over.HasAPI(UsdPhysics.RigidBodyAPI)
-
         # Skip when body1 is a ghost link and no rigid body is assigned to body1.
         # If no rigid body exists, it is confirmed during preprocessing that it is a ghost link.
-        if not body1_has_rigid_body:
+        if not _has_rigid_body(body1_link_name, data):
             continue
+
+        # A ghost link has no rigid body, so a joint targeting one on body0 would detach body1 from
+        # the articulation. Retarget body0 to the closest ancestor link that owns a rigid body.
+        if not _has_rigid_body(body0_link_name, data):
+            body0_link_name = _find_rigid_body_ancestor(body0_link_name, data)
+
+        body0 = data.references[Tokens.Physics][body0_link_name] if body0_link_name else default_prim
+        body1 = data.references[Tokens.Physics][body1_link_name]
 
         # Specifies that the origin position of Body1 (the "child" of the joint in the URDF) is the center.
         joint_frame = usdex.core.JointFrame(usdex.core.JointFrame.Space.Body1, Gf.Vec3d(0), Gf.Quatd.GetIdentity())

--- a/urdf_usd_converter/_impl/link_hierarchy.py
+++ b/urdf_usd_converter/_impl/link_hierarchy.py
@@ -26,6 +26,9 @@ class LinkHierarchy:
         # Store data for Ghost Link.
         self.links: dict[str, dict[str, Any]] = {}
 
+        # A dictionary of link names and their parent links.
+        self.link_parents: dict[str, ElementLink] = {}
+
         # A list of link names that are referenced by mimic joints.
         self.referenced_link_names_by_mimic_joint: list[str] = []
 
@@ -57,6 +60,7 @@ class LinkHierarchy:
                 link = self.get_link_by_name(joint.child.get_with_default("link"))
                 self.link_tree[parent_link_name]["children"].append(link)
                 self.link_tree[parent_link_name]["joints"].append(joint)
+                self.link_parents[link.name] = self.link_tree[parent_link_name]["link"]
 
         # If the link tree is empty, make the first link the root.
         if len(self.link_tree) == 0 and len(self.root_element.links) > 0:
@@ -205,6 +209,14 @@ class LinkHierarchy:
         if link_name not in self.link_tree:
             return []
         return self.link_tree[link_name]["children"]
+
+    def get_link_parent(self, link_name: str) -> ElementLink | None:
+        """
+        Get the parent link of a link, or None when the link is the root.
+        """
+        if link_name not in self.link_parents:
+            return None
+        return self.link_parents[link_name]
 
     def get_link_by_name(self, link_name: str) -> ElementLink:
         """

--- a/urdf_usd_converter/_impl/link_hierarchy.py
+++ b/urdf_usd_converter/_impl/link_hierarchy.py
@@ -212,11 +212,13 @@ class LinkHierarchy:
 
     def get_link_parent(self, link_name: str) -> ElementLink | None:
         """
-        Get the parent link of a link, or None when the link is the root.
+        Get the parent link of a link, or None when the link is the kinematic root.
         """
-        if link_name not in self.link_parents:
+        root_link = self.get_root_link()
+        # The kinematic root has no parent and is not stored in `link_parents`.
+        if root_link is not None and link_name == root_link.name:
             return None
-        return self.link_parents[link_name]
+        return self.link_parents.get(link_name)
 
     def get_link_by_name(self, link_name: str) -> ElementLink:
         """

--- a/urdf_usd_converter/_impl/link_hierarchy.py
+++ b/urdf_usd_converter/_impl/link_hierarchy.py
@@ -38,10 +38,13 @@ class LinkHierarchy:
         # Store the link names that are referenced by mimic joints.
         self._store_referenced_link_names_by_mimic_joint()
 
+        # The root link of the kinematic hierarchy.
+        self.root_link = self._find_root_link()
+
         # Preprocessing is performed to identify Ghost Links.
         # If the end of a link is a Ghost Link, the rigid body associated with that link will be removed.
-        self._ghost_links_chain(None, self.get_root_link())
-        self._check_remove_rigid_body_flag(self.get_root_link())
+        self._ghost_links_chain(None, self.root_link)
+        self._check_remove_rigid_body_flag(self.root_link)
 
     def _create_link_hierarchy(self):
         """
@@ -174,9 +177,9 @@ class LinkHierarchy:
                 break
         return checked
 
-    def get_root_link(self) -> ElementLink:
+    def _find_root_link(self) -> ElementLink:
         """
-        Get the root link name from the link hierarchy.
+        Find the root link from the link hierarchy.
         """
         links = [data["link"] for data in self.link_tree.values()]
         if len(links) == 0:
@@ -214,9 +217,8 @@ class LinkHierarchy:
         """
         Get the parent link of a link, or None when the link is the kinematic root.
         """
-        root_link = self.get_root_link()
         # The kinematic root has no parent and is not stored in `link_parents`.
-        if root_link is not None and link_name == root_link.name:
+        if link_name == self.root_link.name:
             return None
         return self.link_parents.get(link_name)
 
@@ -250,7 +252,7 @@ class LinkHierarchy:
         belongs_to_mimic_joint = self.links[link.name]["belongs_to_mimic_joint"]
 
         # For root links, only 'ghost_link' is used for identification.
-        if link.name == self.get_root_link().name:
+        if link.name == self.root_link.name:
             return ghost_link
 
         return ghost_link and belongs_to_fixed_joint and not belongs_to_mimic_joint


### PR DESCRIPTION
## Description

Fixes #137 

- When a joint's parent is a ghost link without a rigid body, `physics:body0` is retargeted to the closest ancestor that owns one (or the default prim / world if none exists).
- Intermediate ghost links on fixed chains still omit rigid bodies and drop fixed joints whose child has no rigid body; only the surviving joint's body0 is rewritten so articulated descendants stay connected in the physics graph.
- Updated `concept_mapping.md`.

### Related PR

In the following PRs, we had planned to implement something similar but ultimately decided against it.  
This implementation will serve to complement those features.  

- https://github.com/newton-physics/urdf-usd-converter/pull/103
- https://github.com/newton-physics/urdf-usd-converter/pull/107

## Examples

### Example 1: single ghost link (`link_ghost_link_children`)

URDF structure:  
```
BaseLink (rigid body) --fixed(joint1)--> ghost_link (no rigid body) --revolute(joint2)--> box_link (rigid body)
```

Before:   

| Joint | body0 | body1 |
| --- | --- | --- |
| `root_joint` | world | BaseLink |
| `joint1` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint2` | ghost_link *(no rigid body)* | box_link |


After (this fix):  

| Joint | body0 | body1 |
| --- | --- | --- |
| `root_joint` | world | BaseLink |
| `joint1` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint2` | BaseLink *(retargeted from ghost_link)* | box_link |

joint2.localPos0` accumulates the origins of `joint1` and `joint2`.

### Example 2: multiple ghost links (`link_skip_ghost_link_chain`)

URDF structure:

```
BaseLink (rigid body) --fixed(joint1)--> ghost_link (no rigid body) --fixed(joint2)-->
  ghost_link_2 (no rigid body) --fixed(joint3)--> ghost_link_3 (no rigid body) --revolute(joint_box)--> link_box (rigid body)
```

Before:   

| Joint | body0 | body1 |
| --- | --- | --- |
| `root_joint` | world | BaseLink |
| `joint1` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint2` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint3` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint_box` | ghost_link_3 *(no rigid body)* | link_box |

After (this fix):  

| Joint | body0 | body1 |
| --- | --- | --- |
| `root_joint` | world | BaseLink |
| `joint1` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint2` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint3` | *(omitted: child has no rigid body)* | *(omitted)* |
| `joint_box` | BaseLink *(retargeted from ghost_link_3)* | link_box |

`joint_box.localPos0` accumulates the origins of `joint1`, `joint2`, `joint3`, and `joint_box`.

## Unit tests

- URDF: tests/data/link_ghost_link_children.urdf
- Unit test: tests/testGhostLink.py - test_link_ghost_link_children

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
