### PR TITLE
Derive physics:principalAxes from body-frame inertia (fix zero-quat edge case)

### DIFF
--- a/docs/concept_mapping.md
+++ b/docs/concept_mapping.md
@@ -387,11 +387,7 @@ The `origin.xyz` maps to `physics:centerOfMass` attribute of `UsdPhysicsMassAPI`
 
 The `origin.rpy` of an inertial element is the orientation of the inertial frame (in which the URDF inertia tensor is expressed) relative to the link frame. They are stored in URDF as roll, pitch, yaw Euler rotations in radians.
 
-This concept is not directly representable in UsdPhysics as a separate attribute, so it must be baked into both `physics:principalAxes` and `newton:inertia`. See [inertia](#element-inertia) for details. For `physics:principalAxes`, once the aligned axes are obtained from eigenvalue decomposition of the URDF inertia tensor, the rpy should be used to rotate them as follows:
-
-1. Convert rpy from Euler rotation radians to a Quaternion  
-2. `quatf orientedAxes = orientation * principalAxis  `
-3. `physics:principalAxes = orientedAxes`
+This concept is not directly representable in UsdPhysics as a separate attribute, so it must be baked into both `physics:principalAxes` and `newton:inertia`. See [inertia](#element-inertia) for details. In short, `origin.rpy` is used to form the body-frame tensor `I_body = R * I_urdf * R^T`; both USD representations are then derived from that single `I_body`, rather than composing `rpy` onto principal axes after decomposing the unrotated URDF tensor.
 
 ##### Element: mass
 
@@ -407,13 +403,13 @@ The inertia element contains 6 named properties, which can be used to construct 
 [ ixz  iyz  izz ]
 ```
 
-In URDF, this tensor is expressed in the inertial frame defined by [`origin`](#element-origin). In USD, both of the following representations are authored on the link Prim:
+In URDF, this tensor is expressed in the inertial frame defined by [`origin`](#element-origin). In USD, two equivalent representations are authored on the link Prim — the full body-frame tensor (`newton:inertia`) and the principal form (`physics:diagonalInertia` with `physics:principalAxes`) — using that body-frame tensor as the single source of truth:
 
-- `physics:principalAxes` and `physics:diagonalInertia` — computed via eigenvalue decomposition of the URDF inertia tensor, then composing `origin.rpy` into `physics:principalAxes` as described above.
-- `newton:inertia` (`NewtonMassAPI`) — the full symmetric inertia tensor as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]` **in the body's local (link) frame**.
+1. Rotate the URDF tensor into the link frame as `I_body = R * I_urdf * R^T`.
+2. Author `newton:inertia` (`NewtonMassAPI`) from `I_body` as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]` **in the body's local (link) frame**.
+3. Author `physics:diagonalInertia` and `physics:principalAxes` from the eigenvalue decomposition of that same `I_body` (eigenvalues and eigenvectors respectively).
 
-Because `newton:inertia` must be in the body frame, the URDF values must not be copied verbatim when `origin.rpy` is non-identity.  
-Rotate the URDF tensor into the link frame as `I_body = R * I_urdf * R^T`, then author `newton:inertia` from `I_body` as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`.  
+Because both representations must describe inertia in the body frame, the URDF values must not be copied verbatim when `origin.rpy` is non-identity, and `physics:principalAxes` must not be derived by eigendecomposing the unrotated URDF tensor and then composing `origin.rpy` afterward.  
 `R` is built from `origin.rpy` using URDF's fixed-axis (extrinsic) XYZ convention, `R = Rz(yaw) * Ry(pitch) * Rx(roll)`, which is the assumption the whole transform rests on.  
 When `origin` is omitted or `rpy` is identity, `I_body = I_urdf` and the component mapping below matches the URDF attributes directly.  
 `origin.xyz` affects only `physics:centerOfMass`; it does not change the inertia tensor.

--- a/tests/data/inertia_large_degenerate.urdf
+++ b/tests/data/inertia_large_degenerate.urdf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot name="inertia_large_degenerate">
+  <!--
+    Purpose: verify large-magnitude isotropic inertia with non-identity origin.rpy
+    authors canonical identity principalAxes (degeneracy tolerance scales with |I|).
+  -->
+  <link name="link_isotropic_large">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0.37 1.02 -2.9"/>
+      <mass value="1.0"/>
+      <inertia ixx="2000000.0" ixy="0.0" ixz="0.0" iyy="2000000.0" iyz="0.0" izz="2000000.0"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/tests/data/inertia_large_degenerate.urdf
+++ b/tests/data/inertia_large_degenerate.urdf
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <robot name="inertia_large_degenerate">
   <!--
-    Purpose: verify large-magnitude isotropic inertia with non-identity origin.rpy
-    authors canonical identity principalAxes (degeneracy tolerance scales with |I|).
+    Purpose: verify large-magnitude degenerate inertia with non-identity origin.rpy.
+    - link_isotropic_large: fully isotropic (ixx = iyy = izz); principalAxes → identity.
+    - link_pair_degenerate_large: pair-degenerate (ixx = iyy != izz); principalAxes
+      stay scale-invariant under body-frame rotation (degeneracy tolerance scales with |I|).
   -->
   <link name="link_isotropic_large">
     <inertial>
@@ -16,4 +18,21 @@
       </geometry>
     </visual>
   </link>
+  <link name="link_pair_degenerate_large">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0.37 1.02 -2.9"/>
+      <mass value="1.0"/>
+      <inertia ixx="2000000.0" ixy="0.0" ixz="0.0" iyy="2000000.0" iyz="0.0" izz="4000000.0"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+  <joint name="joint_isotropic_to_pair" type="fixed">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <parent link="link_isotropic_large"/>
+    <child link="link_pair_degenerate_large"/>
+  </joint>
 </robot>

--- a/tests/data/inertia_origin_mass_no_inertia.urdf
+++ b/tests/data/inertia_origin_mass_no_inertia.urdf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot name="inertia_origin_mass_no_inertia">
+  <!--
+    Purpose: verify that an <inertial> with origin and mass but no <inertia>
+    authors mass and centerOfMass only — not principalAxes, diagonalInertia,
+    or newton:inertia (which require an inertia tensor).
+  -->
+  <link name="link_origin_mass_only">
+    <inertial>
+      <origin xyz="0 0 0.1" rpy="0.1 0.2 0.3"/>
+      <mass value="1.0"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -195,7 +195,8 @@ class TestPhysicsInertia(ConverterTestCase):
         self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.5), 1e-6))
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 0.8, places=6)
         self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(0.77679752, 2.1640169, 3.0591856), 1e-6))
-        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(-0.0463736, 0.2748650, 0.9481796, 0.1524932))
+        # principalAxes come from eigendecomposition of I_body (not I_urdf composed with rpy).
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(0.9481796, 0.15249318, 0.04637361, -0.27486506))
         # `newton:inertia` is in the body/link frame (URDF inertia rotated by origin.rpy).
         self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
         self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -284,6 +284,49 @@ class TestPhysicsInertia(ConverterTestCase):
         )
         self._assert_inertia_reconstructs(link_prim, 2e6, 2e6, 2e6, 0.0, 0.0, 0.0, rpy=(0.37, 1.02, -2.9))
 
+    def test_large_pair_degenerate_urdf_principal_axes(self):
+        """
+        Assert URDF conversion handles large pair-degenerate inertia (ixx == iyy != izz).
+
+        Exercises `_fix_degenerate_plane` end-to-end: authored principalAxes must
+        match the scale-invariant result from `_extract_inertia`, and reconstruct I_body.
+        """
+        rpy = (0.37, 1.02, -2.9)
+        scale = 2e6
+        input_path = "tests/data/inertia_large_degenerate.urdf"
+        asset_path = urdf_usd_converter.Converter().convert(input_path, self.tmpDir())
+        self.assertIsNotNone(asset_path)
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+        default_prim = stage.GetDefaultPrim()
+        geometry_scope = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        parent_prim = stage.GetPrimAtPath(geometry_scope.GetPath().AppendChild("link_isotropic_large"))
+        link_prim = stage.GetPrimAtPath(parent_prim.GetPath().AppendChild("link_pair_degenerate_large"))
+        self.assertTrue(link_prim.IsValid())
+
+        mass_api = UsdPhysics.MassAPI(link_prim)
+        # Same shape at unit scale must yield the same axes (relative degeneracy tolerance).
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), self._principal_axes(1.0, rpy))
+        # Absolute epsilon (see test_large_isotropic_extract_inertia_is_canonical).
+        self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(scale, scale, 2.0 * scale), 1e-3))
+        # Gf vs NumPy rpy paths differ at ~1e-9 abs for large |I|; use relative tol.
+        expected_body = self._rotation_from_rpy(rpy) @ np.diag([scale, scale, 2.0 * scale]) @ self._rotation_from_rpy(rpy).T
+        expected = [
+            expected_body[0, 0],
+            expected_body[1, 1],
+            expected_body[2, 2],
+            expected_body[0, 1],
+            expected_body[0, 2],
+            expected_body[1, 2],
+        ]
+        inertia = link_prim.GetAttribute("newton:inertia").Get()
+        self.assertTrue(
+            np.allclose(inertia, expected, rtol=1e-12, atol=1e-3),
+            msg=f"newton:inertia {inertia} does not match expected body-frame tensor {expected}",
+        )
+        self._assert_inertia_reconstructs(link_prim, scale, scale, 2.0 * scale, 0.0, 0.0, 0.0, rpy=rpy)
+
     def test_origin_mass_without_inertia_skips_principal_axes(self):
         """
         Assert principalAxes is not authored when <inertial> lacks <inertia>.

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -288,8 +288,8 @@ class TestPhysicsInertia(ConverterTestCase):
         """
         Assert URDF conversion handles large pair-degenerate inertia (ixx == iyy != izz).
 
-        Exercises `_fix_degenerate_plane` end-to-end: authored principalAxes must
-        match the scale-invariant result from `_extract_inertia`, and reconstruct I_body.
+        Authored principalAxes must match the unit-scale result for the same shape
+        (scale-invariant under body-frame rotation) and reconstruct I_body.
         """
         rpy = (0.37, 1.02, -2.9)
         scale = 2e6

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -220,14 +220,15 @@ class TestPhysicsInertia(ConverterTestCase):
         """
         Assert principalAxes depend on inertia shape, not magnitude.
 
-        Same rpy and tensor shape must yield the same quaternion at any scale.
+        Same rpy and tensor shape must yield the same quaternion at any scale,
+        including below 1.0 (a floored absolute tolerance would break that side).
         Uses pair-degenerate tensors (ixx == iyy != izz) so the shipped
         `_canonicalize_eigenvectors` / `_fix_degenerate_plane` path is exercised
         through `_extract_inertia`.
         """
         for rpy in [(0.37, 1.02, -2.9), (0.8606, -1.4465, -2.8841), (0.1, 0.2, 0.3)]:
             reference = self._principal_axes(1.0, rpy)
-            for scale in (1e3, 1e5, 1e6, 1e7):
+            for scale in (1e-10, 1e-9, 1e3, 1e5, 1e6, 1e7):
                 self.assertRotationsAlmostEqual(self._principal_axes(scale, rpy), reference)
 
     def test_large_isotropic_extract_inertia_is_canonical(self):

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -8,6 +8,8 @@ from pxr import Gf, Usd, UsdPhysics
 
 import urdf_usd_converter
 from tests.util.ConverterTestCase import ConverterTestCase
+from urdf_usd_converter._impl.link import _extract_inertia, _inertia_tensor_in_body_frame
+from urdf_usd_converter._impl.urdf_parser.elements import ElementInertia, ElementPose
 
 
 class TestPhysicsInertia(ConverterTestCase):
@@ -200,3 +202,154 @@ class TestPhysicsInertia(ConverterTestCase):
         # `newton:inertia` is in the body/link frame (URDF inertia rotated by origin.rpy).
         self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
         self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
+
+    def _pair_degenerate_body_eigenvalues(self, scale: float, rpy: tuple[float, float, float]) -> np.ndarray:
+        """Eigenvalues of I_body for a pair-degenerate URDF tensor (ixx == iyy != izz)."""
+        inertia = ElementInertia()
+        inertia.ixx = scale
+        inertia.iyy = scale
+        inertia.izz = 2.0 * scale
+        inertia.ixy = 0.0
+        inertia.ixz = 0.0
+        inertia.iyz = 0.0
+        origin = ElementPose()
+        origin.rpy = rpy
+        i_body = _inertia_tensor_in_body_frame(inertia, origin)
+        ixx, iyy, izz, ixy, ixz, iyz = i_body
+        mat = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)
+        return np.linalg.eigh(mat)[0]
+
+    def _degeneracy_miss_rate(self, scale: float, *, relative: bool, n: int = 300, seed: int = 0) -> float:
+        """
+        Fraction of random origin.rpy samples where a pair-degenerate tensor is
+        not detected after rotation into the body frame.
+
+        Absolute 1e-9 becomes load-bearing once I_body carries magnitude-
+        proportional rounding; relative tolerance scales with |eigenvalues|.
+        """
+        rng = np.random.default_rng(seed)
+        misses = 0
+        for _ in range(n):
+            rpy = tuple(float(x) for x in rng.uniform(-math.pi, math.pi, size=3))
+            eigenvalues = self._pair_degenerate_body_eigenvalues(scale, rpy)
+            tol = 1e-9 * max(1.0, float(np.max(np.abs(eigenvalues)))) if relative else 1e-9
+            eq01 = abs(float(eigenvalues[0]) - float(eigenvalues[1])) < tol
+            eq12 = abs(float(eigenvalues[1]) - float(eigenvalues[2])) < tol
+            if not (eq01 or eq12):
+                misses += 1
+        return 100.0 * misses / n
+
+    def test_degeneracy_tolerance_scales_with_inertia_magnitude(self):
+        """
+        Compare absolute vs relative eigenvalue-degeneracy miss rates over random rpy.
+
+        Absolute 1e-9 misses pair-degeneracy more often as |I| grows; relative
+        tolerance detects all samples. Typical observed absolute miss rates over
+        300 random rpy (Gf-built I_body): I~1e5 ~0%, I~1e6 ~10%, I~1e7 ~85%+.
+        """
+        for scale in (1e5, 1e6, 1e7):
+            relative_miss = self._degeneracy_miss_rate(scale, relative=True)
+            self.assertEqual(
+                relative_miss,
+                0.0,
+                msg=f"relative tolerance should detect all degeneracies at scale {scale:g}, miss={relative_miss}%",
+            )
+
+        absolute_1e5 = self._degeneracy_miss_rate(1e5, relative=False)
+        absolute_1e6 = self._degeneracy_miss_rate(1e6, relative=False)
+        absolute_1e7 = self._degeneracy_miss_rate(1e7, relative=False)
+        self.assertEqual(absolute_1e5, 0.0, msg=f"I~1e5 absolute miss rate should be ~0%, got {absolute_1e5}%")
+        self.assertGreater(absolute_1e6, 0.0, msg=f"I~1e6 absolute miss rate should be >0%, got {absolute_1e6}%")
+        self.assertGreater(absolute_1e7, 50.0, msg=f"I~1e7 absolute miss rate should be high, got {absolute_1e7}%")
+        self.assertGreater(absolute_1e7, absolute_1e6)
+
+    def test_large_isotropic_extract_inertia_is_canonical(self):
+        """
+        Assert `_extract_inertia` returns identity axes for a large isotropic tensor.
+
+        Large isotropic I=2e6 with non-identity rpy must still canonicalize to
+        identity principalAxes when eigenvalue degeneracy uses a relative tolerance.
+        """
+        inertia = ElementInertia()
+        inertia.ixx = inertia.iyy = inertia.izz = 2e6
+        inertia.ixy = inertia.ixz = inertia.iyz = 0.0
+        origin = ElementPose()
+        origin.rpy = (0.37, 1.02, -2.9)
+        i_body = _inertia_tensor_in_body_frame(inertia, origin)
+        orientation, diag_inertia = _extract_inertia(i_body)
+        self.assertRotationsAlmostEqual(orientation, Gf.Quatf(1, 0, 0, 0))
+        # Gf.IsClose epsilon is absolute: |a-b| < 1e-3. At scale 2e6 that is still
+        # a tight relative check (~5e-10); looser than the O(1) tests' 1e-6 only
+        # to absorb float32 Vec3f / eigh rounding at large magnitude.
+        self.assertTrue(Gf.IsClose(diag_inertia, Gf.Vec3f(2e6, 2e6, 2e6), 1e-3))
+
+    def test_large_isotropic_urdf_principal_axes_are_canonical(self):
+        """
+        Assert URDF conversion authors identity principalAxes for a large isotropic link.
+
+        Same large isotropic case as above, end-to-end through URDF conversion:
+        authored physics:principalAxes must be the canonical identity.
+        """
+        input_path = "tests/data/inertia_large_degenerate.urdf"
+        asset_path = urdf_usd_converter.Converter().convert(input_path, self.tmpDir())
+        self.assertIsNotNone(asset_path)
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+        default_prim = stage.GetDefaultPrim()
+        geometry_scope = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        link_prim = stage.GetPrimAtPath(geometry_scope.GetPath().AppendChild("link_isotropic_large"))
+        self.assertTrue(link_prim.IsValid())
+
+        mass_api = UsdPhysics.MassAPI(link_prim)
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), Gf.Quatf(1, 0, 0, 0))
+        # Absolute epsilon (see test_large_isotropic_extract_inertia_is_canonical).
+        self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), Gf.Vec3f(2e6, 2e6, 2e6), 1e-3))
+        # Isotropic I_body ≈ s*I; Gf vs NumPy rpy paths differ at ~1e-9 abs, so use relative tol.
+        inertia = link_prim.GetAttribute("newton:inertia").Get()
+        self.assertTrue(
+            np.allclose(inertia[:3], [2e6, 2e6, 2e6], rtol=1e-12, atol=1e-3),
+            msg=f"diagonal newton:inertia {inertia[:3]} not isotropic at 2e6",
+        )
+        self.assertTrue(
+            np.allclose(inertia[3:], [0.0, 0.0, 0.0], atol=1e-6),
+            msg=f"off-diagonal newton:inertia {inertia[3:]} should be ~0",
+        )
+        self._assert_inertia_reconstructs(link_prim, 2e6, 2e6, 2e6, 0.0, 0.0, 0.0, rpy=(0.37, 1.02, -2.9))
+
+    def test_origin_mass_without_inertia_skips_principal_axes(self):
+        """
+        Assert principalAxes is not authored when <inertial> lacks <inertia>.
+
+        mass and centerOfMass should still be authored from the present elements;
+        principalAxes, diagonalInertia, and newton:inertia require an inertia tensor.
+        """
+        input_path = "tests/data/inertia_origin_mass_no_inertia.urdf"
+        asset_path = urdf_usd_converter.Converter().convert(input_path, self.tmpDir())
+        self.assertIsNotNone(asset_path)
+
+        stage: Usd.Stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+        default_prim = stage.GetDefaultPrim()
+        geometry_scope = stage.GetPrimAtPath(default_prim.GetPath().AppendChild("Geometry"))
+        link_prim = stage.GetPrimAtPath(geometry_scope.GetPath().AppendChild("link_origin_mass_only"))
+        self.assertTrue(link_prim.IsValid())
+        self.assertTrue(link_prim.HasAPI(UsdPhysics.MassAPI))
+
+        mass_api = UsdPhysics.MassAPI(link_prim)
+        self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 1.0, places=6)
+        self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0, 0, 0.1), 1e-6))
+        self.assertFalse(
+            mass_api.GetPrincipalAxesAttr().HasAuthoredValue(),
+            msg="physics:principalAxes must not be authored without <inertia>",
+        )
+        self.assertFalse(
+            mass_api.GetDiagonalInertiaAttr().HasAuthoredValue(),
+            msg="physics:diagonalInertia must not be authored without <inertia>",
+        )
+        newton_inertia = link_prim.GetAttribute("newton:inertia")
+        self.assertTrue(newton_inertia)
+        self.assertFalse(
+            newton_inertia.HasAuthoredValue(),
+            msg="newton:inertia must not be authored without <inertia>",
+        )

--- a/tests/testPhysicsInertia.py
+++ b/tests/testPhysicsInertia.py
@@ -203,65 +203,32 @@ class TestPhysicsInertia(ConverterTestCase):
         self._assert_newton_inertia(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
         self._assert_inertia_reconstructs(link_box7_prim, 2.0, 1.0, 3.0, 0.5, 0.25, -0.1, rpy=(0.3, -0.4, 0.5))
 
-    def _pair_degenerate_body_eigenvalues(self, scale: float, rpy: tuple[float, float, float]) -> np.ndarray:
-        """Eigenvalues of I_body for a pair-degenerate URDF tensor (ixx == iyy != izz)."""
+    def _principal_axes(self, scale: float, rpy: tuple[float, float, float], *, izz_factor: float = 2.0) -> Gf.Quatf:
+        """
+        Principal axes from a pair-degenerate (default) or isotropic URDF tensor
+        after rotation into the body frame, via the shipped `_extract_inertia`.
+        """
         inertia = ElementInertia()
-        inertia.ixx = scale
-        inertia.iyy = scale
-        inertia.izz = 2.0 * scale
-        inertia.ixy = 0.0
-        inertia.ixz = 0.0
-        inertia.iyz = 0.0
+        inertia.ixx = inertia.iyy = scale
+        inertia.izz = izz_factor * scale
+        inertia.ixy = inertia.ixz = inertia.iyz = 0.0
         origin = ElementPose()
         origin.rpy = rpy
-        i_body = _inertia_tensor_in_body_frame(inertia, origin)
-        ixx, iyy, izz, ixy, ixz, iyz = i_body
-        mat = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)
-        return np.linalg.eigh(mat)[0]
+        return _extract_inertia(_inertia_tensor_in_body_frame(inertia, origin))[0]
 
-    def _degeneracy_miss_rate(self, scale: float, *, relative: bool, n: int = 300, seed: int = 0) -> float:
+    def test_principal_axes_are_scale_invariant(self):
         """
-        Fraction of random origin.rpy samples where a pair-degenerate tensor is
-        not detected after rotation into the body frame.
+        Assert principalAxes depend on inertia shape, not magnitude.
 
-        Absolute 1e-9 becomes load-bearing once I_body carries magnitude-
-        proportional rounding; relative tolerance scales with |eigenvalues|.
+        Same rpy and tensor shape must yield the same quaternion at any scale.
+        Uses pair-degenerate tensors (ixx == iyy != izz) so the shipped
+        `_canonicalize_eigenvectors` / `_fix_degenerate_plane` path is exercised
+        through `_extract_inertia`.
         """
-        rng = np.random.default_rng(seed)
-        misses = 0
-        for _ in range(n):
-            rpy = tuple(float(x) for x in rng.uniform(-math.pi, math.pi, size=3))
-            eigenvalues = self._pair_degenerate_body_eigenvalues(scale, rpy)
-            tol = 1e-9 * max(1.0, float(np.max(np.abs(eigenvalues)))) if relative else 1e-9
-            eq01 = abs(float(eigenvalues[0]) - float(eigenvalues[1])) < tol
-            eq12 = abs(float(eigenvalues[1]) - float(eigenvalues[2])) < tol
-            if not (eq01 or eq12):
-                misses += 1
-        return 100.0 * misses / n
-
-    def test_degeneracy_tolerance_scales_with_inertia_magnitude(self):
-        """
-        Compare absolute vs relative eigenvalue-degeneracy miss rates over random rpy.
-
-        Absolute 1e-9 misses pair-degeneracy more often as |I| grows; relative
-        tolerance detects all samples. Typical observed absolute miss rates over
-        300 random rpy (Gf-built I_body): I~1e5 ~0%, I~1e6 ~10%, I~1e7 ~85%+.
-        """
-        for scale in (1e5, 1e6, 1e7):
-            relative_miss = self._degeneracy_miss_rate(scale, relative=True)
-            self.assertEqual(
-                relative_miss,
-                0.0,
-                msg=f"relative tolerance should detect all degeneracies at scale {scale:g}, miss={relative_miss}%",
-            )
-
-        absolute_1e5 = self._degeneracy_miss_rate(1e5, relative=False)
-        absolute_1e6 = self._degeneracy_miss_rate(1e6, relative=False)
-        absolute_1e7 = self._degeneracy_miss_rate(1e7, relative=False)
-        self.assertEqual(absolute_1e5, 0.0, msg=f"I~1e5 absolute miss rate should be ~0%, got {absolute_1e5}%")
-        self.assertGreater(absolute_1e6, 0.0, msg=f"I~1e6 absolute miss rate should be >0%, got {absolute_1e6}%")
-        self.assertGreater(absolute_1e7, 50.0, msg=f"I~1e7 absolute miss rate should be high, got {absolute_1e7}%")
-        self.assertGreater(absolute_1e7, absolute_1e6)
+        for rpy in [(0.37, 1.02, -2.9), (0.8606, -1.4465, -2.8841), (0.1, 0.2, 0.3)]:
+            reference = self._principal_axes(1.0, rpy)
+            for scale in (1e3, 1e5, 1e6, 1e7):
+                self.assertRotationsAlmostEqual(self._principal_axes(scale, rpy), reference)
 
     def test_large_isotropic_extract_inertia_is_canonical(self):
         """

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -22,7 +22,6 @@ from .urdf_parser.elements import (
 )
 from .utils import (
     float3_to_quatd,
-    float3_to_quatf,
     get_geometry_name,
     set_schema_attribute,
     set_transform,
@@ -156,21 +155,19 @@ def apply_inertial(prim: Usd.Prim, link: ElementLink, data: ConversionData):
     prim_over.ApplyAPI("NewtonMassAPI")
 
     if link.inertial and link.inertial.inertia:
-        inertia = link.inertial.inertia
-        orientation, diag_inertia = extract_inertia(inertia)
+        # `newton:inertia` is in body local frame
+        i_body = _inertia_tensor_in_body_frame(link.inertial.inertia, link.inertial.origin)
+        set_schema_attribute(prim_over, "newton:inertia", i_body)
+
+        # Derive principal axes from I_body so `physics:*` and `newton:inertia` share one source.
+        # I_body already includes origin.rpy, so do not compose rpy onto principalAxes again.
+        orientation, diag_inertia = _extract_inertia(i_body)
         mass_api.GetPrincipalAxesAttr().Set(orientation)
         mass_api.GetDiagonalInertiaAttr().Set(diag_inertia)
 
-        # `newton:inertia` is in body local frame
-        i_body = _inertia_tensor_in_body_frame(inertia, link.inertial.origin)
-        set_schema_attribute(prim_over, "newton:inertia", i_body)
-
     if link.inertial.origin:
         position = Gf.Vec3f(link.inertial.origin.get_with_default("xyz"))
-        orientation = float3_to_quatf(link.inertial.origin.get_with_default("rpy"))
         mass_api.GetCenterOfMassAttr().Set(position)
-        axes = mass_api.GetPrincipalAxesAttr().Get()
-        mass_api.GetPrincipalAxesAttr().Set(orientation * axes)
 
     if link.inertial.mass:
         mass = link.inertial.mass.get_with_default("value")
@@ -249,23 +246,18 @@ def _canonicalize_eigenvectors(eigenvalues: np.ndarray, eigenvectors: np.ndarray
             eigenvectors[:, -1] = -eigenvectors[:, -1]
 
 
-def extract_inertia(inertia: ElementInertia) -> tuple[Gf.Quatf, Gf.Vec3f]:
+def _extract_inertia(i_body: list[float]) -> tuple[Gf.Quatf, Gf.Vec3f]:
     """
     Extract the principal moments of inertia (diagonal inertia) and orientation
-    from URDF link inertia tensor using eigenvalue decomposition.
+    from a body-frame inertia tensor using eigenvalue decomposition.
 
     Args:
-        inertia: URDF inertia tensor element
+        i_body: Symmetric inertia tensor as `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`
 
     Returns:
         tuple[Gf.Quatf, Gf.Vec3f]: (orientation, diagonal_inertia)
     """
-    ixx = inertia.get_with_default("ixx")
-    ixy = inertia.get_with_default("ixy")
-    ixz = inertia.get_with_default("ixz")
-    iyy = inertia.get_with_default("iyy")
-    iyz = inertia.get_with_default("iyz")
-    izz = inertia.get_with_default("izz")
+    ixx, iyy, izz, ixy, ixz, iyz = i_body
 
     # Build inertia tensor matrix (symmetric matrix)
     mat = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -221,9 +221,10 @@ def _canonicalize_eigenvectors(eigenvalues: np.ndarray, eigenvectors: np.ndarray
 
     Modifies eigenvectors in place.
     """
-    # Absolute 1e-9 is too tight once I_body = R I_urdf R^T introduces
-    # magnitude-proportional rounding; scale the threshold with |eigenvalues|.
-    tol = 1e-9 * max(1.0, float(np.max(np.abs(eigenvalues))))
+    # Magnitude-proportional rounding after I_body = R I_urdf R^T requires a
+    # relative degeneracy tolerance (no absolute floor — that misclassifies
+    # fully anisotropic tensors whose |eigenvalues| are below 1.0).
+    tol = 1e-9 * float(np.max(np.abs(eigenvalues)))
     eq01 = abs(float(eigenvalues[0]) - float(eigenvalues[1])) < tol
     eq12 = abs(float(eigenvalues[1]) - float(eigenvalues[2])) < tol
     if eq01 and eq12:

--- a/urdf_usd_converter/_impl/link.py
+++ b/urdf_usd_converter/_impl/link.py
@@ -221,8 +221,11 @@ def _canonicalize_eigenvectors(eigenvalues: np.ndarray, eigenvectors: np.ndarray
 
     Modifies eigenvectors in place.
     """
-    eq01 = abs(float(eigenvalues[0]) - float(eigenvalues[1])) < 1e-9
-    eq12 = abs(float(eigenvalues[1]) - float(eigenvalues[2])) < 1e-9
+    # Absolute 1e-9 is too tight once I_body = R I_urdf R^T introduces
+    # magnitude-proportional rounding; scale the threshold with |eigenvalues|.
+    tol = 1e-9 * max(1.0, float(np.max(np.abs(eigenvalues))))
+    eq01 = abs(float(eigenvalues[0]) - float(eigenvalues[1])) < tol
+    eq12 = abs(float(eigenvalues[1]) - float(eigenvalues[2])) < tol
     if eq01 and eq12:
         # All three equal: use identity (canonical default).
         # Spherical symmetry, etc.
@@ -268,7 +271,7 @@ def _extract_inertia(i_body: list[float]) -> tuple[Gf.Quatf, Gf.Vec3f]:
     eigenvalues, eigenvectors = np.linalg.eigh(mat)
 
     # In the case of two degenerate eigenvalues, the corresponding eigenvectors are not unique.
-    # Detect degeneracy with absolute tolerance and canonicalize the eigenvector matrix.
+    # Detect degeneracy with a magnitude-relative tolerance and canonicalize the eigenvector matrix.
     _canonicalize_eigenvectors(eigenvalues, eigenvectors)
 
     # Use eigenvalues as diagonal inertia


### PR DESCRIPTION
## Description

Fixes #135 

- derive `physics:diagonalInertia` and `physics:principalAxes` from the body-frame inertia tensor `I_body = R * I_urdf * R^T`, the same source used for `newton:inertia`.
- Because principal axes are now taken from the eigendecomposition of `I_body` itself, the previous follow-up step of composing `origin.rpy` onto `principalAxes` is no longer needed, keeping both USD inertia representations consistent.
- Updated `docs/concept_mapping.md` and the `link_box7` principal-axes expectation in `tests/testPhysicsInertia.py`.
  - The updated quaternion is physically equivalent to the previous one for inertia purposes (the principal axes differ only by sign flips, i.e. a 180° relative rotation about a principal axis); the substantive check remains `self._assert_inertia_reconstructs`, which verifies that `R(principalAxes) @ diag @ R^T` reconstructs `I_body`.
  - The `link_box7` quaternion change restores the repo's eigenvector sign convention: previously axes were canonicalized on the unrotated URDF tensor and then `origin.rpy` was composed on top, which does not preserve per-column sign / `det = +1` heuristics. Deriving axes from `I_body` keeps canonicalization in the same frame. The old and new rotations differ by a 180° flip about a principal axis, so `R diag R^T` is unchanged (`_assert_inertia_reconstructs`).
- Also stops authoring an invalid zero `physics:principalAxes` when `<inertial>` has `origin`/`mass` but no `<inertia>`.  
On main, the origin block composed rpy onto the unauthored `(0,0,0,0)` fallback; principal axes are now authored only when `<inertia>` is present.
 
## Unit tests
 
- urdf: tests/data/inertia_large_degenerate.urdf
- urdf: tests/data/inertia_origin_mass_no_inertia.urdf

- tests/testPhysicsInertia.py
  - test_principal_axes_are_scale_invariant (Verifying Internal Functions)
    Assert principalAxes depend on inertia shape, not magnitude.
  - test_large_isotropic_extract_inertia_is_canonical  (Verifying Internal Functions) 
    Checks `_extract_inertia` returns identity principal axes for a large isotropic tensor with non-identity rpy.
  - test_large_isotropic_urdf_principal_axes_are_canonical  
    Verifies that a large isotropic inertia with non-identity `origin.rpy` still converts to identity `physics:principalAxes` (and matching `diagonal` / `newton:inertia`).
  - test_large_pair_degenerate_urdf_principal_axes  
    Assert URDF conversion handles large pair-degenerate inertia (ixx == iyy != izz).
  - test_origin_mass_without_inertia_skips_principal_axes  
    Verifies that when `<inertial>` has origin and mass but no `<inertia>`, the converter authors mass and center of mass only, and does not author `principalAxes`, `diagonalInertia`, or `newton:inertia`.
    
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/urdf-usd-converter/blob/HEAD/CONTRIBUTING.md).
