### PR TITLE
Add GLB mesh conversion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Added static GLB mesh conversion using trimesh, including node transforms, normals, UVs, and basic PBR material factors
+
 # 0.3.3
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Added static GLB mesh conversion using trimesh, including node transforms, normals, UVs, and basic PBR material factors
+- Added static GLB mesh conversion using trimesh, including node transforms, normals, UVs, PBR material factors, and embedded base-color, normal, emissive, and metallic-roughness textures
 
 # 0.3.3
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Key Features:
 - Converts an input URDF file into an OpenUSD Layer
 - Supports data conversion of visual geometry & materials, as well as the links, collision geometry, and joints necessary for kinematic simulation.
 - Available as a python module or command line interface (CLI).
-- Creates a standalone, self-contained artifact with no connection to the source URDF, OBJ, DAE, or STL data.
+- Creates a standalone, self-contained artifact with no connection to the source URDF, OBJ, DAE, STL, or GLB data.
   - Structured as an [Atomic Component](https://docs.omniverse.nvidia.com/usd/latest/learn-openusd/independent/asset-structure-principles.html#atomic-model-structure-flowerpot)
   - Suitable for visualization & rendering in any OpenUSD Ecosystem application.
   - Suitable for import & simulation in [Newton](https://github.com/newton-physics/newton).
@@ -26,7 +26,9 @@ The output asset structure is based on NVIDIA's [Principles of Scalable Asset St
 The implementation also leverages the following dependencies:
 - NVIDIA's [OpenUSD Exchange SDK](https://docs.omniverse.nvidia.com/usd/code-docs/usd-exchange-sdk/latest/index.html) to author consistent & correct USD data.
 - Pixar's OpenUSD python modules & native libraries (vendored via the `usd-exchange` wheel).
-- [tinyobjloader](https://github.com/tinyobjloader/tinyobjloader), [pycollada](https://github.com/pycollada/pycollada), and [numpy-stl](https://numpy-stl.readthedocs.io) for parsing any mesh data referenced by the input URDF datasets.
+- [tinyobjloader](https://github.com/tinyobjloader/tinyobjloader), [pycollada](https://github.com/pycollada/pycollada), [numpy-stl](https://numpy-stl.readthedocs.io), and [trimesh](https://trimesh.org/) for parsing any mesh data referenced by the input URDF datasets.
+
+GLB support covers static triangle meshes, node transforms, vertex normals, UVs, and basic PBR material factors. Textures, animations, skins, morph targets, and glTF extensions are not supported.
 
 # Get Started
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The implementation also leverages the following dependencies:
 - Pixar's OpenUSD python modules & native libraries (vendored via the `usd-exchange` wheel).
 - [tinyobjloader](https://github.com/tinyobjloader/tinyobjloader), [pycollada](https://github.com/pycollada/pycollada), [numpy-stl](https://numpy-stl.readthedocs.io), and [trimesh](https://trimesh.org/) for parsing any mesh data referenced by the input URDF datasets.
 
-GLB support covers static triangle meshes, node transforms, vertex normals, UVs, and basic PBR material factors. Textures, animations, skins, morph targets, and glTF extensions are not supported.
+GLB support covers static triangle meshes, node transforms, vertex normals, UVs, PBR material factors, and embedded PNG/JPEG base-color, normal, emissive, and metallic-roughness textures. Animations, skins, morph targets, occlusion textures, alternate UV sets, non-default texture samplers, and glTF extensions are not supported.
 
 # Get Started
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "usd-exchange>=2.2.2",
     "newton-usd-schemas>=0.4.0",
     "numpy-stl>=3.2",
+    "pillow>=11",
     "tinyobjloader>=2.0.0rc13",
     "pycollada>=0.9.2",
     "trimesh>=4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
     "pycollada>=0.9.2",
+    "trimesh>=4.6",
 ]
 
 [project.urls]

--- a/tests/testMeshGlb.py
+++ b/tests/testMeshGlb.py
@@ -6,6 +6,7 @@ import numpy as np
 import trimesh
 import usdex.core
 import usdex.test
+from PIL import Image
 from pxr import Gf, Tf, Usd, UsdGeom, UsdShade
 
 import urdf_usd_converter
@@ -13,12 +14,22 @@ from tests.util.ConverterTestCase import ConverterTestCase
 
 
 def _write_glb(path: pathlib.Path):
+    base_color = Image.fromarray(np.full((2, 2, 4), [255, 128, 64, 128], dtype=np.uint8))
+    metallic_roughness = Image.fromarray(np.full((2, 2, 3), [0, 128, 64], dtype=np.uint8))
+    normal = Image.fromarray(np.full((2, 2, 3), [128, 128, 255], dtype=np.uint8))
+    emissive = Image.fromarray(np.full((2, 2, 3), [32, 64, 128], dtype=np.uint8))
     material = trimesh.visual.material.PBRMaterial(
         name="test_material",
         baseColorFactor=[64, 128, 191, 128],
+        baseColorTexture=base_color,
         metallicFactor=0.2,
+        metallicRoughnessTexture=metallic_roughness,
         roughnessFactor=0.4,
         emissiveFactor=[0.1, 0.2, 0.3],
+        emissiveTexture=emissive,
+        normalTexture=normal,
+        alphaMode="MASK",
+        alphaCutoff=0.25,
     )
     visual = trimesh.visual.texture.TextureVisuals(
         uv=np.asarray([[0, 0], [1, 0], [0, 1]], dtype=np.float64),
@@ -89,13 +100,29 @@ class TestMeshGlb(ConverterTestCase):
 
         material = UsdShade.Material(stage.GetPrimAtPath("/glb_import/Materials/test_material"))
         self.assertTrue(material)
-        self.assertTrue(Gf.IsClose(self.get_material_diffuse_color(material), Gf.Vec3f(64 / 255, 128 / 255, 191 / 255), 1e-6))
-        self.assertTrue(Gf.IsClose(self.get_material_emissive_color(material), Gf.Vec3f(0.1, 0.2, 0.3), 1e-6))
-        self.assertAlmostEqual(self.get_material_opacity(material), 128 / 255)
-        self.assertAlmostEqual(self.get_material_metallic(material), 0.2)
-        self.assertAlmostEqual(self.get_material_roughness(material), 0.4)
+        self.assertTrue(
+            Gf.IsClose(
+                self._texture_scale(material, "DiffuseTexture"),
+                Gf.Vec4f(64 / 255, 128 / 255, 191 / 255, 128 / 255),
+                1e-6,
+            )
+        )
+        self.assertEqual(self._texture_scale(material, "RoughnessTexture"), Gf.Vec4f(0.4))
+        self.assertEqual(self._texture_scale(material, "MetallicTexture"), Gf.Vec4f(0.2))
+        self.assertEqual(self._texture_scale(material, "OpacityTexture"), Gf.Vec4f(128 / 255))
+        self.assertEqual(self._texture_scale(material, "EmissiveTexture"), Gf.Vec4f(0.1, 0.2, 0.3, 1.0))
+        self.assertEqual(material.GetInput("opacityThreshold").Get(), 0.25)
         for mesh in meshes:
             self.check_material_binding(mesh.GetPrim(), material)
+
+        texture_dir = root / "output" / "Payload" / "Textures"
+        self.assertEqual(len(list(texture_dir.iterdir())), 4)
+        for input_name in ["diffuseColor", "emissiveColor", "normal", "roughness", "metallic", "opacity"]:
+            texture_path = self.get_material_texture_path(material, input_name)
+            self.assertTrue((root / "output" / "Payload" / texture_path).is_file())
+        self.assertEqual(self._connected_output(material, "roughness"), "g")
+        self.assertEqual(self._connected_output(material, "metallic"), "b")
+        self.assertEqual(self._connected_output(material, "opacity"), "a")
 
     def test_invalid_glb_uses_existing_mesh_warning(self):
         root = pathlib.Path(self.tmpDir())
@@ -113,3 +140,12 @@ class TestMeshGlb(ConverterTestCase):
             asset_path = urdf_usd_converter.Converter().convert(urdf_path, root / "output")
 
         self.assertIsValidUsd(Usd.Stage.Open(asset_path.path))
+
+    @staticmethod
+    def _connected_output(material: UsdShade.Material, input_name: str) -> str:
+        surface = usdex.core.computeEffectivePreviewSurfaceShader(material)
+        return str(surface.GetInput(input_name).GetConnectedSource()[1])
+
+    @staticmethod
+    def _texture_scale(material: UsdShade.Material, shader_name: str) -> Gf.Vec4f:
+        return UsdShade.Shader(material.GetPrim().GetChild(shader_name)).GetInput("scale").Get()

--- a/tests/testMeshGlb.py
+++ b/tests/testMeshGlb.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import numpy as np
+import trimesh
+import usdex.core
+import usdex.test
+from pxr import Gf, Tf, Usd, UsdGeom, UsdShade
+
+import urdf_usd_converter
+from tests.util.ConverterTestCase import ConverterTestCase
+
+
+def _write_glb(path: pathlib.Path):
+    material = trimesh.visual.material.PBRMaterial(
+        name="test_material",
+        baseColorFactor=[64, 128, 191, 128],
+        metallicFactor=0.2,
+        roughnessFactor=0.4,
+        emissiveFactor=[0.1, 0.2, 0.3],
+    )
+    visual = trimesh.visual.texture.TextureVisuals(
+        uv=np.asarray([[0, 0], [1, 0], [0, 1]], dtype=np.float64),
+        material=material,
+    )
+    mesh = trimesh.Trimesh(
+        vertices=[[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+        faces=[[0, 1, 2]],
+        vertex_normals=[[0, 0, 1]] * 3,
+        visual=visual,
+        process=False,
+    )
+    scene = trimesh.Scene()
+    for name, translation in [("first", [1, 2, 3]), ("second", [-2, 0, 0])]:
+        scene.add_geometry(
+            mesh,
+            node_name=name,
+            geom_name="triangle",
+            transform=trimesh.transformations.translation_matrix(translation),
+        )
+    path.write_bytes(scene.export(file_type="glb"))
+
+
+def _write_urdf(path: pathlib.Path):
+    path.write_text(
+        """<?xml version="1.0"?>
+<robot name="glb_import">
+  <link name="link_glb">
+    <visual>
+      <geometry><mesh filename="static_mesh.glb"/></geometry>
+    </visual>
+  </link>
+</robot>
+""",
+        encoding="utf-8",
+    )
+
+
+class TestMeshGlb(ConverterTestCase):
+    def test_static_glb_scene(self):
+        root = pathlib.Path(self.tmpDir())
+        glb_path = root / "static_mesh.glb"
+        urdf_path = root / "glb_import.urdf"
+        _write_glb(glb_path)
+        _write_urdf(urdf_path)
+
+        asset_path = urdf_usd_converter.Converter().convert(urdf_path, root / "output")
+
+        stage = Usd.Stage.Open(asset_path.path)
+        self.assertIsValidUsd(stage)
+        root_prim = stage.GetPrimAtPath("/glb_import/Geometry/link_glb/static_mesh")
+        meshes = [UsdGeom.Mesh(child) for child in root_prim.GetChildren() if child.IsA(UsdGeom.Mesh)]
+        self.assertEqual(len(meshes), 2)
+
+        first_points = sorted(tuple(mesh.GetPointsAttr().Get()[0]) for mesh in meshes)
+        self.assertEqual(first_points, [(-2.0, 0.0, 0.0), (1.0, 2.0, 3.0)])
+        for mesh in meshes:
+            self.assertEqual(list(mesh.GetFaceVertexCountsAttr().Get()), [3])
+            self.assertEqual(list(mesh.GetFaceVertexIndicesAttr().Get()), [0, 1, 2])
+
+            primvars = UsdGeom.PrimvarsAPI(mesh)
+            normals = primvars.GetPrimvar("normals")
+            uvs = primvars.GetPrimvar("st")
+            self.assertEqual(normals.GetInterpolation(), UsdGeom.Tokens.vertex)
+            self.assertEqual(uvs.GetInterpolation(), UsdGeom.Tokens.vertex)
+            self.assertEqual(len(normals.Get()), 1)
+            self.assertEqual(len(uvs.Get()), 3)
+
+        material = UsdShade.Material(stage.GetPrimAtPath("/glb_import/Materials/test_material"))
+        self.assertTrue(material)
+        self.assertTrue(Gf.IsClose(self.get_material_diffuse_color(material), Gf.Vec3f(64 / 255, 128 / 255, 191 / 255), 1e-6))
+        self.assertTrue(Gf.IsClose(self.get_material_emissive_color(material), Gf.Vec3f(0.1, 0.2, 0.3), 1e-6))
+        self.assertAlmostEqual(self.get_material_opacity(material), 128 / 255)
+        self.assertAlmostEqual(self.get_material_metallic(material), 0.2)
+        self.assertAlmostEqual(self.get_material_roughness(material), 0.4)
+        for mesh in meshes:
+            self.check_material_binding(mesh.GetPrim(), material)
+
+    def test_invalid_glb_uses_existing_mesh_warning(self):
+        root = pathlib.Path(self.tmpDir())
+        glb_path = root / "static_mesh.glb"
+        urdf_path = root / "glb_import.urdf"
+        _write_glb(glb_path)
+        glb_path.write_bytes(b"BAD!" + glb_path.read_bytes()[4:])
+        _write_urdf(urdf_path)
+
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Failed to convert mesh:.*incorrect header on GLB file.*")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset_path = urdf_usd_converter.Converter().convert(urdf_path, root / "output")
+
+        self.assertIsValidUsd(Usd.Stage.Open(asset_path.path))

--- a/urdf_usd_converter/_impl/conversion_gltf.py
+++ b/urdf_usd_converter/_impl/conversion_gltf.py
@@ -5,9 +5,10 @@ import pathlib
 import numpy as np
 import trimesh
 import usdex.core
+from PIL import Image
 from pxr import Gf, Tf, Usd, UsdGeom, Vt
 
-from .data import ConversionData
+from .data import ConversionData, Tokens
 from .material import store_mesh_material_reference
 from .material_data import MaterialData
 from .numpy import convert_vec2f_array, convert_vec3f_array
@@ -31,6 +32,8 @@ def convert_glb(prim: Usd.Prim, input_path: pathlib.Path, data: ConversionData) 
 
     material_names: dict[int, str] = {}
     used_material_names: set[str] = set()
+    texture_directory = pathlib.Path(data.content[Tokens.Contents].GetRootLayer().identifier).parent / Tokens.Textures
+    texture_paths: dict[int, pathlib.Path] = {}
     converted = 0
     for geometry_name, transform, mesh in nodes:
         if not isinstance(mesh, trimesh.Trimesh):
@@ -54,6 +57,8 @@ def convert_glb(prim: Usd.Prim, input_path: pathlib.Path, data: ConversionData) 
             mesh,
             material_names,
             used_material_names,
+            texture_directory,
+            texture_paths,
             data,
         )
         if material_name:
@@ -150,6 +155,8 @@ def _store_material(
     mesh: trimesh.Trimesh,
     material_names: dict[int, str],
     used_material_names: set[str],
+    texture_directory: pathlib.Path,
+    texture_paths: dict[int, pathlib.Path],
     data: ConversionData,
 ) -> str | None:
     material = getattr(mesh.visual, "material", None)
@@ -171,6 +178,9 @@ def _store_material(
 
     base_color = _color_factor(material.baseColorFactor, 4, [1.0, 1.0, 1.0, 1.0])
     emissive = _color_factor(material.emissiveFactor, 3, [0.0, 0.0, 0.0])
+    metallic = float(material.metallicFactor if material.metallicFactor is not None else 1.0)
+    roughness = float(material.roughnessFactor if material.roughnessFactor is not None else 1.0)
+    alpha_mode = material.alphaMode or "OPAQUE"
 
     material_data = MaterialData()
     material_data.mesh_file_path = input_path
@@ -178,11 +188,68 @@ def _store_material(
     material_data.material_name = material.name
     material_data.diffuse_color = usdex.core.linearToSrgb(Gf.Vec3f(*base_color[:3]))
     material_data.emissive_color = usdex.core.linearToSrgb(Gf.Vec3f(*emissive))
-    material_data.opacity = float(base_color[3])
-    material_data.metallic = float(material.metallicFactor if material.metallicFactor is not None else 1.0)
-    material_data.roughness = float(material.roughnessFactor if material.roughnessFactor is not None else 1.0)
+    material_data.opacity = 1.0 if alpha_mode == "OPAQUE" else float(base_color[3])
+    material_data.metallic = metallic
+    material_data.roughness = roughness
+    if alpha_mode == "MASK":
+        material_data.opacity_threshold = float(material.alphaCutoff if material.alphaCutoff is not None else 0.5)
+
+    base_color_texture = _extract_texture(material.baseColorTexture, texture_directory, texture_paths)
+    if base_color_texture:
+        material_data.diffuse_texture_path = base_color_texture
+        material_data.diffuse_texture_scale = Gf.Vec4f(*base_color)
+        if alpha_mode != "OPAQUE":
+            material_data.opacity_texture_path = base_color_texture
+            material_data.opacity_texture_channel = "a"
+            material_data.opacity_texture_scale = float(base_color[3])
+
+    metallic_roughness_texture = _extract_texture(material.metallicRoughnessTexture, texture_directory, texture_paths)
+    if metallic_roughness_texture:
+        material_data.roughness_texture_path = metallic_roughness_texture
+        material_data.roughness_texture_channel = "g"
+        material_data.roughness_texture_scale = roughness
+        material_data.metallic_texture_path = metallic_roughness_texture
+        material_data.metallic_texture_channel = "b"
+        material_data.metallic_texture_scale = metallic
+
+    material_data.normal_texture_path = _extract_texture(material.normalTexture, texture_directory, texture_paths)
+    material_data.emissive_texture_path = _extract_texture(material.emissiveTexture, texture_directory, texture_paths)
+    if material_data.emissive_texture_path:
+        material_data.emissive_texture_scale = Gf.Vec4f(emissive[0], emissive[1], emissive[2], 1.0)
+
     data.material_data_list.append(material_data)
     return name
+
+
+def _extract_texture(
+    image: Image.Image | None,
+    texture_directory: pathlib.Path,
+    texture_paths: dict[int, pathlib.Path],
+) -> pathlib.Path | None:
+    if image is None:
+        return None
+    if not isinstance(image, Image.Image):
+        Tf.Warn(f"Ignoring unsupported GLB texture type: {type(image).__name__}")
+        return None
+
+    key = id(image)
+    if key in texture_paths:
+        return texture_paths[key]
+
+    image_format = (image.format or "PNG").upper()
+    suffix = {"JPG": ".jpg", "JPEG": ".jpg", "PNG": ".png", "WEBP": ".webp"}.get(image_format, ".png")
+    texture_directory.mkdir(parents=True, exist_ok=True)
+    texture_path = texture_directory / f"glb_texture_{len(tuple(texture_directory.iterdir())):03d}{suffix}"
+
+    source = getattr(image, "fp", None)
+    payload = source.getvalue() if hasattr(source, "getvalue") else None
+    if payload and image_format in {"JPEG", "PNG", "WEBP"}:
+        texture_path.write_bytes(payload)
+    else:
+        image.save(texture_path, format=image_format if image_format in {"JPEG", "PNG", "WEBP"} else "PNG")
+
+    texture_paths[key] = texture_path
+    return texture_path
 
 
 def _color_factor(value, size: int, default: list[float]) -> np.ndarray:

--- a/urdf_usd_converter/_impl/conversion_gltf.py
+++ b/urdf_usd_converter/_impl/conversion_gltf.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import numpy as np
+import trimesh
+import usdex.core
+from pxr import Gf, Tf, Usd, UsdGeom, Vt
+
+from .data import ConversionData
+from .material import store_mesh_material_reference
+from .material_data import MaterialData
+from .numpy import convert_vec2f_array, convert_vec3f_array
+
+__all__ = ["convert_glb"]
+
+
+def convert_glb(prim: Usd.Prim, input_path: pathlib.Path, data: ConversionData) -> Usd.Prim:
+    """Convert static meshes from a binary glTF scene."""
+    with input_path.open("rb") as stream:
+        scene = trimesh.load_scene(stream, file_type="glb", process=False)
+
+    nodes = []
+    for node_name in scene.graph.nodes_geometry:
+        transform, geometry_name = scene.graph[node_name]
+        nodes.append((str(geometry_name), np.asarray(transform, dtype=np.float64), scene.geometry[geometry_name]))
+
+    nodes.sort(key=lambda item: (item[0], tuple(item[1].flat)))
+    if not nodes:
+        raise ValueError("GLB contains no mesh geometry")
+
+    material_names: dict[int, str] = {}
+    used_material_names: set[str] = set()
+    converted = 0
+    for geometry_name, transform, mesh in nodes:
+        if not isinstance(mesh, trimesh.Trimesh):
+            Tf.Warn(f'Unsupported GLB geometry "{geometry_name}" in "{input_path}"')
+            continue
+
+        usd_mesh = _convert_mesh(
+            prim,
+            geometry_name,
+            mesh,
+            transform,
+            single_mesh=len(nodes) == 1,
+            data=data,
+        )
+        if not usd_mesh:
+            continue
+
+        material_name = _store_material(
+            input_path,
+            geometry_name,
+            mesh,
+            material_names,
+            used_material_names,
+            data,
+        )
+        if material_name:
+            store_mesh_material_reference(input_path, usd_mesh.GetPrim().GetName(), [material_name], data)
+        converted += 1
+
+    if converted == 0:
+        raise ValueError("GLB contains no supported triangle meshes")
+    return prim
+
+
+def _convert_mesh(
+    prim: Usd.Prim,
+    geometry_name: str,
+    mesh: trimesh.Trimesh,
+    transform: np.ndarray,
+    single_mesh: bool,
+    data: ConversionData,
+) -> UsdGeom.Mesh | None:
+    vertices = trimesh.transformations.transform_points(mesh.vertices, transform)
+    faces = np.asarray(mesh.faces, dtype=np.int32)
+    if faces.ndim != 2 or faces.shape[1] != 3 or len(vertices) == 0 or len(faces) == 0:
+        Tf.Warn(f'Unsupported non-triangle or empty GLB mesh "{geometry_name}"')
+        return None
+
+    if np.linalg.det(transform[:3, :3]) < 0.0:
+        faces = np.fliplr(faces)
+
+    normals = _transform_normals(mesh, transform, geometry_name)
+    uvs = getattr(mesh.visual, "uv", None)
+    if uvs is not None:
+        uvs = np.asarray(uvs, dtype=np.float32)
+        if uvs.shape != (len(vertices), 2):
+            Tf.Warn(f'Ignoring invalid UVs on GLB mesh "{geometry_name}"')
+            uvs = None
+
+    if single_mesh:
+        parent = prim.GetParent()
+        safe_name = prim.GetName()
+    else:
+        parent = prim
+        safe_name = data.name_cache.getPrimName(prim, geometry_name)
+
+    normal_data = None
+    if normals is not None:
+        normal_data = usdex.core.Vec3fPrimvarData(UsdGeom.Tokens.vertex, convert_vec3f_array(normals))
+        normal_data.index()
+
+    uv_data = None
+    if uvs is not None:
+        uv_data = usdex.core.Vec2fPrimvarData(UsdGeom.Tokens.vertex, convert_vec2f_array(uvs))
+        uv_data.index()
+
+    usd_mesh = usdex.core.definePolyMesh(
+        parent,
+        safe_name,
+        faceVertexCounts=Vt.IntArray([3] * len(faces)),
+        faceVertexIndices=Vt.IntArray.FromNumpy(np.ascontiguousarray(faces).reshape(-1)),
+        points=convert_vec3f_array(np.asarray(vertices, dtype=np.float32)),
+        normals=normal_data,
+        uvs=uv_data,
+    )
+    if not usd_mesh:
+        Tf.Warn(f'Failed to convert GLB mesh "{geometry_name}"')
+        return None
+
+    if geometry_name != safe_name:
+        usdex.core.setDisplayName(usd_mesh.GetPrim(), geometry_name)
+    return usd_mesh
+
+
+def _transform_normals(mesh: trimesh.Trimesh, transform: np.ndarray, geometry_name: str) -> np.ndarray | None:
+    normals = np.asarray(mesh.vertex_normals, dtype=np.float64)
+    if normals.shape != (len(mesh.vertices), 3):
+        Tf.Warn(f'Ignoring invalid normals on GLB mesh "{geometry_name}"')
+        return None
+
+    try:
+        normals = normals @ np.linalg.inv(transform[:3, :3])
+    except np.linalg.LinAlgError:
+        Tf.Warn(f'Ignoring normals on GLB mesh "{geometry_name}" because its transform is singular')
+        return None
+
+    lengths = np.linalg.norm(normals, axis=1)
+    if np.any(lengths == 0.0):
+        Tf.Warn(f'Ignoring zero-length normals on GLB mesh "{geometry_name}"')
+        return None
+    return np.asarray(normals / lengths[:, None], dtype=np.float32)
+
+
+def _store_material(
+    input_path: pathlib.Path,
+    geometry_name: str,
+    mesh: trimesh.Trimesh,
+    material_names: dict[int, str],
+    used_material_names: set[str],
+    data: ConversionData,
+) -> str | None:
+    material = getattr(mesh.visual, "material", None)
+    if not isinstance(material, trimesh.visual.material.PBRMaterial):
+        return None
+
+    key = id(material)
+    if key in material_names:
+        return material_names[key]
+
+    base_name = material.name or f"{geometry_name}_material"
+    name = base_name
+    suffix = 1
+    while name in used_material_names:
+        suffix += 1
+        name = f"{base_name}_{suffix}"
+    used_material_names.add(name)
+    material_names[key] = name
+
+    base_color = _color_factor(material.baseColorFactor, 4, [1.0, 1.0, 1.0, 1.0])
+    emissive = _color_factor(material.emissiveFactor, 3, [0.0, 0.0, 0.0])
+
+    material_data = MaterialData()
+    material_data.mesh_file_path = input_path
+    material_data.name = name
+    material_data.material_name = material.name
+    material_data.diffuse_color = usdex.core.linearToSrgb(Gf.Vec3f(*base_color[:3]))
+    material_data.emissive_color = usdex.core.linearToSrgb(Gf.Vec3f(*emissive))
+    material_data.opacity = float(base_color[3])
+    material_data.metallic = float(material.metallicFactor if material.metallicFactor is not None else 1.0)
+    material_data.roughness = float(material.roughnessFactor if material.roughnessFactor is not None else 1.0)
+    data.material_data_list.append(material_data)
+    return name
+
+
+def _color_factor(value, size: int, default: list[float]) -> np.ndarray:
+    if value is None:
+        return np.asarray(default, dtype=np.float64)
+
+    factor = np.asarray(value, dtype=np.float64).reshape(-1)
+    if len(factor) != size:
+        return np.asarray(default, dtype=np.float64)
+    if np.issubdtype(np.asarray(value).dtype, np.integer) or np.max(factor) > 1.0:
+        factor = factor / 255.0
+    return factor

--- a/urdf_usd_converter/_impl/material.py
+++ b/urdf_usd_converter/_impl/material.py
@@ -85,8 +85,9 @@ def _copy_textures(material_cache: MaterialCache, data: ConversionData):
             unique_file_name = material_cache.texture_paths[texture_path]
 
             local_texture_path = local_texture_dir / unique_file_name
-            shutil.copyfile(texture_path, local_texture_path)
-            Tf.Status(f"Copied texture {texture_path} to {local_texture_path}")
+            if texture_path != local_texture_path:
+                shutil.copyfile(texture_path, local_texture_path)
+                Tf.Status(f"Copied texture {texture_path} to {local_texture_path}")
 
 
 def _convert_material(
@@ -129,32 +130,69 @@ def _convert_material(
     surface_shader: UsdShade.Shader = usdex.core.computeEffectivePreviewSurfaceShader(material_prim)
     if material_data.ior != 0.0:
         surface_shader.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(material_data.ior)
+    if material_data.opacity_threshold is not None:
+        surface_shader.CreateInput("opacityThreshold", Sdf.ValueTypeNames.Float).Set(material_data.opacity_threshold)
 
     if material_data.diffuse_texture_path:
         usdex.core.addDiffuseTextureToPreviewMaterial(material_prim, _get_texture_asset_path(material_data.diffuse_texture_path, texture_paths, data))
+        if material_data.diffuse_texture_scale is not None:
+            _configure_texture_scale(material_prim, "DiffuseTexture", material_data.diffuse_texture_scale, usdex.core.ColorSpace.eSrgb)
 
     if material_data.normal_texture_path:
         usdex.core.addNormalTextureToPreviewMaterial(material_prim, _get_texture_asset_path(material_data.normal_texture_path, texture_paths, data))
 
     if material_data.roughness_texture_path:
-        usdex.core.addRoughnessTextureToPreviewMaterial(
-            material_prim, _get_texture_asset_path(material_data.roughness_texture_path, texture_paths, data)
-        )
+        roughness_path = _get_texture_asset_path(material_data.roughness_texture_path, texture_paths, data)
+        if material_data.roughness_texture_channel == "r" and material_data.roughness_texture_scale == 1.0:
+            usdex.core.addRoughnessTextureToPreviewMaterial(material_prim, roughness_path)
+        else:
+            _add_scalar_texture_to_preview_material(
+                material_prim,
+                "roughness",
+                "RoughnessTexture",
+                roughness_path,
+                material_data.roughness_texture_channel,
+                material_data.roughness_texture_scale,
+            )
 
     if material_data.metallic_texture_path:
-        usdex.core.addMetallicTextureToPreviewMaterial(
-            material_prim, _get_texture_asset_path(material_data.metallic_texture_path, texture_paths, data)
-        )
+        metallic_path = _get_texture_asset_path(material_data.metallic_texture_path, texture_paths, data)
+        if material_data.metallic_texture_channel == "r" and material_data.metallic_texture_scale == 1.0:
+            usdex.core.addMetallicTextureToPreviewMaterial(material_prim, metallic_path)
+        else:
+            _add_scalar_texture_to_preview_material(
+                material_prim,
+                "metallic",
+                "MetallicTexture",
+                metallic_path,
+                material_data.metallic_texture_channel,
+                material_data.metallic_texture_scale,
+            )
 
     if material_data.opacity_texture_path:
-        usdex.core.addOpacityTextureToPreviewMaterial(material_prim, _get_texture_asset_path(material_data.opacity_texture_path, texture_paths, data))
+        opacity_path = _get_texture_asset_path(material_data.opacity_texture_path, texture_paths, data)
+        if material_data.opacity_texture_channel == "r" and material_data.opacity_texture_scale == 1.0:
+            usdex.core.addOpacityTextureToPreviewMaterial(material_prim, opacity_path)
+        else:
+            _add_scalar_texture_to_preview_material(
+                material_prim,
+                "opacity",
+                "OpacityTexture",
+                opacity_path,
+                material_data.opacity_texture_channel,
+                material_data.opacity_texture_scale,
+            )
 
     # Add the emissive color to the preview material.
     if emissive_color != [0, 0, 0] or material_data.emissive_texture_path:
         surface_shader.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f).Set(emissive_color)
         if material_data.emissive_texture_path:
             _add_color_texture_to_preview_material(
-                material_prim, "emissiveColor", "EmissiveTexture", _get_texture_asset_path(material_data.emissive_texture_path, texture_paths, data)
+                material_prim,
+                "emissiveColor",
+                "EmissiveTexture",
+                _get_texture_asset_path(material_data.emissive_texture_path, texture_paths, data),
+                material_data.emissive_texture_scale,
             )
 
     # Add the material interface.
@@ -170,7 +208,13 @@ def _convert_material(
     return material_prim
 
 
-def _add_color_texture_to_preview_material(material_prim: UsdShade.Material, input_name: str, shader_name: str, texture_path: Sdf.AssetPath):
+def _add_color_texture_to_preview_material(
+    material_prim: UsdShade.Material,
+    input_name: str,
+    shader_name: str,
+    texture_path: Sdf.AssetPath,
+    scale: Gf.Vec4f | None = None,
+):
     """
     Add the color texture(e.g., specular, emissive) to the preview material.
 
@@ -192,10 +236,52 @@ def _add_color_texture_to_preview_material(material_prim: UsdShade.Material, inp
     fallback = Gf.Vec4f(color[0], color[1], color[2], 1.0)
 
     # Acquire the texture reader.
-    texture_reader: UsdShade.Shader = _acquire_texture_reader(material_prim, shader_name, texture_path, usdex.core.ColorSpace.eAuto, fallback)
+    texture_reader: UsdShade.Shader = _acquire_texture_reader(material_prim, shader_name, texture_path, usdex.core.ColorSpace.eSrgb, fallback)
+    if scale is not None:
+        texture_reader.CreateInput("fallback", Sdf.ValueTypeNames.Float4).Set(Gf.Vec4f(1.0))
+        texture_reader.CreateInput("scale", Sdf.ValueTypeNames.Float4).Set(scale)
 
     # Connect the PreviewSurface shader "input_name" to the color texture shader output
     color_input.ConnectToSource(texture_reader.CreateOutput("rgb", Sdf.ValueTypeNames.Float3))
+
+
+def _add_scalar_texture_to_preview_material(
+    material_prim: UsdShade.Material,
+    input_name: str,
+    shader_name: str,
+    texture_path: Sdf.AssetPath,
+    output_name: str,
+    scale: float,
+):
+    surface = usdex.core.computeEffectivePreviewSurfaceShader(material_prim)
+    scalar_input = surface.GetInput(input_name)
+    if not scalar_input:
+        scalar_input = surface.CreateInput(input_name, Sdf.ValueTypeNames.Float)
+    scalar_input.GetAttr().Clear()
+
+    texture_reader = _acquire_texture_reader(
+        material_prim,
+        shader_name,
+        texture_path,
+        usdex.core.ColorSpace.eRaw,
+        Gf.Vec4f(1.0),
+    )
+    texture_reader.CreateInput("scale", Sdf.ValueTypeNames.Float4).Set(Gf.Vec4f(scale, scale, scale, scale))
+    scalar_input.ConnectToSource(texture_reader.CreateOutput(output_name, Sdf.ValueTypeNames.Float))
+
+
+def _configure_texture_scale(
+    material_prim: UsdShade.Material,
+    shader_name: str,
+    scale: Gf.Vec4f,
+    color_space: usdex.core.ColorSpace,
+):
+    shader = UsdShade.Shader(material_prim.GetPrim().GetChild(shader_name))
+    if not shader:
+        return
+    shader.CreateInput("fallback", Sdf.ValueTypeNames.Float4).Set(Gf.Vec4f(1.0))
+    shader.CreateInput("scale", Sdf.ValueTypeNames.Float4).Set(scale)
+    shader.CreateInput("sourceColorSpace", Sdf.ValueTypeNames.Token).Set(usdex.core.getColorSpaceToken(color_space))
 
 
 def _acquire_texture_reader(

--- a/urdf_usd_converter/_impl/material_data.py
+++ b/urdf_usd_converter/_impl/material_data.py
@@ -39,6 +39,7 @@ class MaterialData:
         self.specular_color: Gf.Vec3f = Gf.Vec3f(0.0, 0.0, 0.0)
         self.emissive_color: Gf.Vec3f = Gf.Vec3f(0.0, 0.0, 0.0)
         self.opacity: float = 1.0
+        self.opacity_threshold: float | None = None
         self.roughness: float = 0.5
         self.metallic: float = 0.0
         self.ior: float = 0.0
@@ -50,6 +51,15 @@ class MaterialData:
         self.roughness_texture_path: pathlib.Path | None = None
         self.metallic_texture_path: pathlib.Path | None = None
         self.opacity_texture_path: pathlib.Path | None = None
+
+        self.diffuse_texture_scale: Gf.Vec4f | None = None
+        self.emissive_texture_scale: Gf.Vec4f | None = None
+        self.roughness_texture_scale: float = 1.0
+        self.metallic_texture_scale: float = 1.0
+        self.opacity_texture_scale: float = 1.0
+        self.roughness_texture_channel: str = "r"
+        self.metallic_texture_channel: str = "r"
+        self.opacity_texture_channel: str = "r"
 
     def get_display_name(self) -> str:
         """

--- a/urdf_usd_converter/_impl/mesh.py
+++ b/urdf_usd_converter/_impl/mesh.py
@@ -9,6 +9,7 @@ import usdex.core
 from pxr import Tf, Usd, UsdGeom, UsdShade, Vt
 
 from .conversion_collada import convert_collada
+from .conversion_gltf import convert_glb
 from .data import ConversionData, Tokens
 from .material import store_mesh_material_reference, store_obj_material_data
 from .numpy import convert_vec2f_array, convert_vec3f_array
@@ -63,6 +64,8 @@ def convert_mesh(prim: Usd.Prim, input_path: pathlib.Path, data: ConversionData)
         convert_obj(prim, input_path, data)
     elif input_path.suffix.lower() == ".dae":
         convert_collada(prim, input_path, data)
+    elif input_path.suffix.lower() == ".glb":
+        convert_glb(prim, input_path, data)
     elif not input_path.is_dir():
         Tf.Warn(f"Unsupported mesh format: {input_path}")
     else:

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,19 @@ wheels = [
 ]
 
 [[package]]
+name = "trimesh"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/45/5b9943631f265073bb96ca4cc2a9de05d151cd8c1a6896fcbaac132a1355/trimesh-5.0.0.tar.gz", hash = "sha256:0195003198baaf2550aebe612254ba2f01c385cec46c37ecc5beca8291f79a13", size = 864019, upload-time = "2026-08-01T00:05:25.042Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/19a03ba344ecb66ea8caab697b3059e0fbea576420f99945944c479caa78/trimesh-5.0.0-py3-none-any.whl", hash = "sha256:51ec67d7f9f74b918f2a695da5fd511b9c084e96307648ae83f45b58f13f8009", size = 745494, upload-time = "2026-08-01T00:05:23.172Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +599,7 @@ dependencies = [
     { name = "numpy-stl" },
     { name = "pycollada" },
     { name = "tinyobjloader" },
+    { name = "trimesh" },
     { name = "usd-exchange" },
 ]
 
@@ -606,6 +620,7 @@ requires-dist = [
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "pycollada", specifier = ">=0.9.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
+    { name = "trimesh", specifier = ">=4.6" },
     { name = "usd-exchange", specifier = ">=2.2.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -331,6 +331,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/c2/669d88644cddb1485bd9534e63e8cf476c8e51cb3c3a1297677023505c0e/pillow-12.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6c0016e7b354317c4e9e525b937ac8596c38d2d232b419529b9cd7a1cd46e39a", size = 5392418, upload-time = "2026-07-01T11:53:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ba/3762f376a2948e3036488d773a146e0ae6ecc2ca03ac20e2615bd0b2ba02/pillow-12.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcc33feacfaefce60c12fd500a277533bdc02b10a19f7f6d348763d8140bbba7", size = 4785287, upload-time = "2026-07-01T11:53:29.761Z" },
+    { url = "https://files.pythonhosted.org/packages/07/50/b5d688cc9c52d4482f3d5bcab6ce20bc2a74a85d2343841c907444a3be2c/pillow-12.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5594fc43d548a7ed94949d139aa1341b270f1863f11cfd37f5a6c8b778a6b67f", size = 6253754, upload-time = "2026-07-01T11:53:32.298Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/89/36f4cd76cf4baf05c50ababb976249153f18c959171c7f6ba09a6f217260/pillow-12.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0606c8bf2cdefea14a43530f7657cbbb7ecf1c4222512492ef4a4434a9501ec", size = 6925605, upload-time = "2026-07-01T11:53:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c0/4de58cf6633b9e3a6061ef4be6fb91fc3c90b812ece886f531e3c523d777/pillow-12.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:85f998ea1848bc6757289e739cfbdda3a04adfd58b02fc018ce54d754a5ce468", size = 6327788, upload-time = "2026-07-01T11:53:36.433Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/14d53682a19550dbbaf3b598f807d5457646c510805a44c7d7891cd1cd1a/pillow-12.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25b9b82bb22e6e2b3cd07b39c68b7b862001226cb3dff7130d1cb914121b39ed", size = 7036288, upload-time = "2026-07-01T11:53:38.712Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1d/36279e3c77efe034e4cc2b0393ee74ffdb5a62391dacbf9b916154f5f0b8/pillow-12.3.0-cp310-cp310-win32.whl", hash = "sha256:37dc8f7bbb66efe481bb60defacef820c950c24713fb44962ed6aa2a50966de1", size = 6472396, upload-time = "2026-07-01T11:53:40.781Z" },
+    { url = "https://files.pythonhosted.org/packages/48/7c/8fa0039574c476d7c6fa57dd7c32a130436877c6ec1e5ce1cc8ec44878c1/pillow-12.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:300557495eb45ebb8aec96c2da9c4be642fbf7cd937278b4013ba894ea8eb0eb", size = 7226887, upload-time = "2026-07-01T11:53:42.764Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/17/e324be141d173c1c919428066c3259f21c1b8982e564e01a4a81e96dbdcf/pillow-12.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:514435a37670e3e5e08f3945b68718b6ed329bb84367777e16f9f4dfe1e61a0f", size = 2568039, upload-time = "2026-07-01T11:53:45.372Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -597,6 +637,7 @@ source = { editable = "." }
 dependencies = [
     { name = "newton-usd-schemas" },
     { name = "numpy-stl" },
+    { name = "pillow" },
     { name = "pycollada" },
     { name = "tinyobjloader" },
     { name = "trimesh" },
@@ -618,6 +659,7 @@ dev = [
 requires-dist = [
     { name = "newton-usd-schemas", specifier = ">=0.4.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
+    { name = "pillow", specifier = ">=11" },
     { name = "pycollada", specifier = ">=0.9.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
     { name = "trimesh", specifier = ">=4.6" },


### PR DESCRIPTION
## Summary

- Add static GLB mesh conversion using trimesh.
- Preserve node transforms, normals, UVs, PBR factors, and embedded PBR textures.
- Add focused regression tests and documentation.

## Tests

- uv run --group dev poe lint
- uv run --group dev poe test

Closes #110